### PR TITLE
feat(terminal): add AWS Kiro CLI adapter

### DIFF
--- a/jmeter-ai-sample.properties
+++ b/jmeter-ai-sample.properties
@@ -44,6 +44,23 @@ Analyzing and optimizing JMeter test plans \
 - JMeter scripting and configuration \
 - Write, debug, and test Java code \
 - Write, debug, and test Groovy script
+# AWS Kiro CLI (kiro-cli) - enabled by default
+jmeter.ai.terminal.kiro.enabled=true
+# Optional: full path to the kiro-cli binary. Leave blank to auto-detect on PATH
+# and in Kiro's default install location.
+# Windows example: C:\Users\YOUR_USER_NAME\.kiro\bin\kiro-cli.exe
+# Linux/macOS example: /home/YOUR_USER_NAME/.kiro/bin/kiro-cli
+jmeter.ai.terminal.kiro.path=
+jmeter.ai.terminal.kiro.prompt=You are an AI assistant integrated into Apache JMeter via the FeatherWand plugin. \
+You have access to the current JMeter test plan structure. \
+Help the user with performance testing tasks including: \
+Analyzing and optimizing JMeter test plans \
+- Creating new test elements (Thread Groups, Samplers, Assertions, etc.) \
+- Debugging test plan issues \
+- Performance testing best practices \
+- JMeter scripting and configuration \
+- Write, debug, and test Java code \
+- Write, debug, and test Groovy script
 # Antigravity CLI (Google) - disabled by default
 jmeter.ai.terminal.antigravity.enabled=false
 jmeter.ai.terminal.antigravity.prompt=You are an AI assistant integrated into Apache JMeter via the FeatherWand plugin. \

--- a/src/main/java/org/qainsights/jmeter/ai/claudecode/ClaudeCodePanel.java
+++ b/src/main/java/org/qainsights/jmeter/ai/claudecode/ClaudeCodePanel.java
@@ -116,6 +116,10 @@ public class ClaudeCodePanel extends JPanel {
         if (antigravity.isEnabled() && antigravity.detect())
             available.add(antigravity);
 
+        AiCliAdapter kiro = new KiroCliAdapter();
+        if (kiro.isEnabled() && kiro.detect())
+            available.add(kiro);
+
         return available;
     }
 
@@ -262,6 +266,13 @@ public class ClaudeCodePanel extends JPanel {
                                 Files.write(claudeMdFile.toPath(),
                                         systemPrompt.getBytes(StandardCharsets.UTF_8));
                                 log.info("Wrote CLAUDE.md to: {}", claudeMdFile.getAbsolutePath());
+
+                                // AWS Kiro (and other agents) read AGENTS.md / KIRO.md
+                                // instead of CLAUDE.md, so mirror the same context there.
+                                Files.write(new File(testPlanDir, "AGENTS.md").toPath(),
+                                        systemPrompt.getBytes(StandardCharsets.UTF_8));
+                                Files.write(new File(testPlanDir, "KIRO.md").toPath(),
+                                        systemPrompt.getBytes(StandardCharsets.UTF_8));
                             } catch (Exception e) {
                                 log.warn("Could not write CLAUDE.md", e);
                                 claudeMdFile = null;

--- a/src/main/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapter.java
+++ b/src/main/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapter.java
@@ -1,0 +1,117 @@
+package org.qainsights.jmeter.ai.claudecode;
+
+import org.qainsights.jmeter.ai.utils.AiConfig;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Adapter for the <strong>AWS Kiro</strong> agentic CLI ({@code kiro-cli}).
+ *
+ * <p>Kiro is not found by a plain {@code PATH} scan in two common situations on
+ * Windows: its binary is {@code kiro-cli.exe} (not {@code claude}/{@code codex}/…),
+ * and its installer adds {@code %USERPROFILE%\.kiro\bin} to the user PATH only for
+ * <em>newly</em> launched processes — an already-running JMeter never sees it.
+ * This adapter therefore resolves the binary in three steps:
+ *
+ * <ol>
+ *   <li>an explicit {@code jmeter.ai.terminal.kiro.path} override;</li>
+ *   <li>the system {@code PATH} ({@code kiro-cli}, then {@code kiro});</li>
+ *   <li>Kiro's well-known default install locations.</li>
+ * </ol>
+ *
+ * <p>The terminal launches Kiro interactively with {@code kiro-cli chat}; the test
+ * plan context is supplied via the {@code AGENTS.md}/{@code KIRO.md} files that
+ * {@code ClaudeCodePanel} writes into the working directory.
+ */
+public class KiroCliAdapter extends BaseCliAdapter {
+
+    @Override
+    public String getName() {
+        return "AWS Kiro";
+    }
+
+    @Override
+    public boolean detect() {
+        // 1) Explicit override wins.
+        String override = AiConfig.getProperty("jmeter.ai.terminal.kiro.path", "");
+        if (override != null && !override.trim().isEmpty()) {
+            File f = new File(expandHome(override.trim()));
+            if (f.isFile()) {
+                detectedPath = f.getAbsolutePath();
+                return true;
+            }
+        }
+
+        // 2) System PATH (handles kiro-cli and the shorter kiro alias).
+        String onPath = findOnPath("kiro-cli");
+        if (onPath == null) {
+            onPath = findOnPath("kiro");
+        }
+        if (onPath != null) {
+            detectedPath = onPath;
+            return true;
+        }
+
+        // 3) Kiro's default install locations (covers the stale-PATH case).
+        for (File candidate : defaultInstallCandidates()) {
+            if (candidate.isFile()) {
+                detectedPath = candidate.getAbsolutePath();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private List<File> defaultInstallCandidates() {
+        List<File> out = new ArrayList<>();
+        String home = System.getProperty("user.home", "");
+        boolean isWindows = System.getProperty("os.name", "").toLowerCase().contains("win");
+        if (isWindows) {
+            out.add(Paths.get(home, ".kiro", "bin", "kiro-cli.exe").toFile());
+            String localAppData = System.getenv("LOCALAPPDATA");
+            if (localAppData != null && !localAppData.trim().isEmpty()) {
+                out.add(Paths.get(localAppData, "Programs", "kiro", "bin", "kiro-cli.exe").toFile());
+                out.add(Paths.get(localAppData, "kiro", "bin", "kiro-cli.exe").toFile());
+            }
+        } else {
+            out.add(Paths.get(home, ".kiro", "bin", "kiro-cli").toFile());
+            out.add(new File("/usr/local/bin/kiro-cli"));
+            out.add(new File("/opt/kiro/bin/kiro-cli"));
+        }
+        return out;
+    }
+
+    private static String expandHome(String path) {
+        if (path.equals("~") || path.startsWith("~/") || path.startsWith("~\\")) {
+            return System.getProperty("user.home", "") + path.substring(1);
+        }
+        return path;
+    }
+
+    @Override
+    public List<String> buildCommand(String workingDirectory) {
+        // Launch Kiro's interactive terminal UI. Kiro reads AGENTS.md / KIRO.md
+        // from the working directory for test-plan context.
+        List<String> command = super.buildCommand(workingDirectory);
+        command.add("chat");
+        return command;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return AiConfig.getProperty("jmeter.ai.terminal.kiro.enabled", "true").equals("true");
+    }
+
+    @Override
+    public String defaultPrompt() {
+        return AiConfig.getProperty("jmeter.ai.terminal.kiro.prompt",
+                "You are an AI assistant integrated into Apache JMeter via the FeatherWand plugin. " +
+                        "You have access to the current JMeter test plan structure. " +
+                        "Help the user with performance testing tasks: analyzing and optimizing JMeter " +
+                        "test plans, creating test elements, debugging issues, performance best practices, " +
+                        "and writing/debugging Groovy and Java (JSR223) code.");
+    }
+}

--- a/src/test/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapterTest.java
+++ b/src/test/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapterTest.java
@@ -1,0 +1,96 @@
+package org.qainsights.jmeter.ai.claudecode;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link KiroCliAdapter}.
+ * <p>
+ * The protected {@link BaseCliAdapter#findOnPath(String)} is overridden in
+ * anonymous subclasses so tests never invoke a real system process.
+ */
+class KiroCliAdapterTest {
+
+    // ── getName ────────────────────────────────────────────────────────────────
+
+    @Test
+    void getName_returnsAwsKiro() {
+        assertEquals("AWS Kiro", new KiroCliAdapter().getName());
+    }
+
+    @Test
+    void toString_returnsAwsKiro() {
+        assertEquals("AWS Kiro", new KiroCliAdapter().toString());
+    }
+
+    // ── getBinaryPath before detect ────────────────────────────────────────────
+
+    @Test
+    void getBinaryPath_returnsNullBeforeDetect() {
+        assertNull(new KiroCliAdapter().getBinaryPath());
+    }
+
+    // ── detect ─────────────────────────────────────────────────────────────────
+
+    @Test
+    void detect_whenKiroCliOnPath_returnsTrueAndSetsPath() {
+        KiroCliAdapter adapter = new KiroCliAdapter() {
+            @Override
+            protected String findOnPath(String binaryName) {
+                return "kiro-cli".equals(binaryName) ? "/home/me/.kiro/bin/kiro-cli" : null;
+            }
+        };
+        assertTrue(adapter.detect());
+        assertEquals("/home/me/.kiro/bin/kiro-cli", adapter.getBinaryPath());
+    }
+
+    @Test
+    void detect_prefersKiroCliOverShortKiroAlias() {
+        String[] firstQueried = {null};
+        KiroCliAdapter adapter = new KiroCliAdapter() {
+            @Override
+            protected String findOnPath(String binaryName) {
+                if (firstQueried[0] == null) {
+                    firstQueried[0] = binaryName;
+                }
+                return null;
+            }
+        };
+        adapter.detect();
+        assertEquals("kiro-cli", firstQueried[0]);
+    }
+
+    @Test
+    void detect_fallsBackToKiroAliasWhenKiroCliMissing() {
+        KiroCliAdapter adapter = new KiroCliAdapter() {
+            @Override
+            protected String findOnPath(String binaryName) {
+                return "kiro".equals(binaryName) ? "/usr/local/bin/kiro" : null;
+            }
+        };
+        assertTrue(adapter.detect());
+        assertEquals("/usr/local/bin/kiro", adapter.getBinaryPath());
+    }
+
+    // ── buildCommand ───────────────────────────────────────────────────────────
+
+    @Test
+    void buildCommand_afterDetect_appendsChatSubcommand() {
+        KiroCliAdapter adapter = new KiroCliAdapter() {
+            @Override
+            protected String findOnPath(String binaryName) {
+                return "/usr/local/bin/kiro-cli";
+            }
+        };
+        adapter.detect();
+
+        List<String> command = adapter.buildCommand(null);
+
+        assertEquals(2, command.size());
+        assertEquals("/usr/local/bin/kiro-cli", command.get(0));
+        assertEquals("chat", command.get(1));
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for the **AWS Kiro** agentic CLI (`kiro-cli`) to the embedded AI terminal, alongside Claude Code, Codex, OpenCode, Copilot, and Antigravity.

Engineers who use Kiro currently hit **"No AI CLIs were detected on your PATH"** because the terminal only scans for `claude`/`codex`/`opencode`/`copilot`/`agy`. Kiro ships as `kiro-cli` and installs to `%USERPROFILE%\.kiro\bin`, so it was never found.

## Changes

- **`KiroCliAdapter`** — new `AiCliAdapter` (extends `BaseCliAdapter`) that resolves the binary in three steps:
  1. explicit `jmeter.ai.terminal.kiro.path` override;
  2. system `PATH` (`kiro-cli`, then the `kiro` alias);
  3. Kiro's default install locations (e.g. `%USERPROFILE%\.kiro\bin\kiro-cli.exe`, `~/.kiro/bin/kiro-cli`).

  Step 3 specifically fixes the common Windows case where the Kiro installer updated the user `PATH` but an **already-running JMeter** never picked it up. Launches `kiro-cli chat`; enabled by default.
- **`ClaudeCodePanel`** — register the adapter in `detectAvailableClis()`, and mirror the generated system prompt to `AGENTS.md` / `KIRO.md` (Kiro reads those rather than `CLAUDE.md`) so Kiro receives the same test-plan context.
- **`jmeter-ai-sample.properties`** — document the new `jmeter.ai.terminal.kiro.{enabled,path,prompt}` keys.
- **`KiroCliAdapterTest`** — unit tests for name, detection precedence (PATH override of `kiro-cli` vs `kiro` alias), and `buildCommand`.

## Testing

`mvn clean test` → **BUILD SUCCESS**, 22 tests pass including the new `KiroCliAdapterTest` (7/7). All changes are Java 8 compatible to match the project baseline.

## Notes

- Headless Kiro (`--no-interactive`) needs `KIRO_API_KEY` (Pro tier+); this PR uses the interactive `kiro-cli chat` flow in the JediTerm terminal, consistent with the other adapters.
- References: [Kiro CLI docs](https://kiro.dev/docs/cli/), [Kiro CLI 2.0 (Windows + headless)](https://kiro.dev/blog/cli-2-0/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for the AWS Kiro CLI in the embedded terminal to auto-detect and launch `kiro-cli` for interactive chats. Also mirrors the system prompt to `AGENTS.md`/`KIRO.md` so Kiro receives the same test-plan context.

- **New Features**
  - Added `KiroCliAdapter` with 3-step detection: config override (`jmeter.ai.terminal.kiro.path`), `PATH` (`kiro-cli` then `kiro`), and known install dirs (incl. `%USERPROFILE%\.kiro\bin`). Starts `kiro-cli chat`. Enabled by default.
  - Registered in `ClaudeCodePanel` and mirrored the prompt to `AGENTS.md` and `KIRO.md`.
  - Documented `jmeter.ai.terminal.kiro.enabled`, `.path`, and `.prompt` in `jmeter-ai-sample.properties`.

<sup>Written for commit 4d2fb176ae8ed6839e926a29925619cc7d56a7cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/QAInsights/jmeter-ai/pull/61?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

