### PR TITLE
feat(security): redact secrets in AI context + governed Kiro tool-trust

### DIFF
--- a/jmeter-ai-sample.properties
+++ b/jmeter-ai-sample.properties
@@ -44,6 +44,23 @@ Analyzing and optimizing JMeter test plans \
 - JMeter scripting and configuration \
 - Write, debug, and test Java code \
 - Write, debug, and test Groovy script
+# AWS Kiro CLI (kiro-cli) - enabled by default
+jmeter.ai.terminal.kiro.enabled=true
+# Optional: full path to the kiro-cli binary. Leave blank to auto-detect on PATH
+# and in Kiro's default install location.
+# Windows example: C:\Users\YOUR_USER_NAME\.kiro\bin\kiro-cli.exe
+# Linux/macOS example: /home/YOUR_USER_NAME/.kiro/bin/kiro-cli
+jmeter.ai.terminal.kiro.path=
+jmeter.ai.terminal.kiro.prompt=You are an AI assistant integrated into Apache JMeter via the FeatherWand plugin. \
+You have access to the current JMeter test plan structure. \
+Help the user with performance testing tasks including: \
+Analyzing and optimizing JMeter test plans \
+- Creating new test elements (Thread Groups, Samplers, Assertions, etc.) \
+- Debugging test plan issues \
+- Performance testing best practices \
+- JMeter scripting and configuration \
+- Write, debug, and test Java code \
+- Write, debug, and test Groovy script
 # Antigravity CLI (Google) - disabled by default
 jmeter.ai.terminal.antigravity.enabled=false
 jmeter.ai.terminal.antigravity.prompt=You are an AI assistant integrated into Apache JMeter via the FeatherWand plugin. \

--- a/jmeter-ai-sample.properties
+++ b/jmeter-ai-sample.properties
@@ -27,6 +27,14 @@ jmeter.ai.correlation.min_value_length=3
 # Higher values require more randomness. Set to 0 to disable entropy-based detection.
 jmeter.ai.correlation.min_entropy=2.8
 
+##### AI Security / Governance #####
+# Redact secrets (passwords, tokens, API keys, bearer/JWT) from the test-plan
+# context before it is written to CLAUDE.md / AGENTS.md / KIRO.md and sent to any
+# AI CLI. Strongly recommended; set to false only in trusted, offline setups.
+jmeter.ai.security.redaction.enabled=true
+# Optional extra key fragments to redact, comma-separated (e.g. pin,otp,ssn)
+jmeter.ai.security.redaction.extra_keys=
+
 ##### AI Terminal Settings #####
 jmeter.ai.terminal.claudecode.enabled=true
 # Full path containing the claude executable
@@ -51,6 +59,11 @@ jmeter.ai.terminal.kiro.enabled=true
 # Windows example: C:\Users\YOUR_USER_NAME\.kiro\bin\kiro-cli.exe
 # Linux/macOS example: /home/YOUR_USER_NAME/.kiro/bin/kiro-cli
 jmeter.ai.terminal.kiro.path=
+# Tool-trust policy. Defaults to read-only tools so the agent cannot mutate the
+# test plan or filesystem without an explicit opt-in. Admins can lock this in a
+# managed user.properties. Set trust_all_tools=true only for trusted operators.
+jmeter.ai.terminal.kiro.trust_tools=read,grep,fs_read
+jmeter.ai.terminal.kiro.trust_all_tools=false
 jmeter.ai.terminal.kiro.prompt=You are an AI assistant integrated into Apache JMeter via the FeatherWand plugin. \
 You have access to the current JMeter test plan structure. \
 Help the user with performance testing tasks including: \

--- a/src/main/java/org/qainsights/jmeter/ai/claudecode/ClaudeCodePanel.java
+++ b/src/main/java/org/qainsights/jmeter/ai/claudecode/ClaudeCodePanel.java
@@ -262,17 +262,22 @@ public class ClaudeCodePanel extends JPanel {
                         // by PtyProcessBuilder, causing stray text to be sent as user input)
                         if (testPlanDir != null) {
                             try {
+                                // Redact secrets (passwords, tokens, API keys) before any
+                                // context leaves JMeter for an external AI CLI. Enabled by
+                                // default; see jmeter.ai.security.redaction.enabled.
+                                byte[] contextBytes = org.qainsights.jmeter.ai.security.SecretRedactor
+                                        .redact(systemPrompt).getBytes(StandardCharsets.UTF_8);
+
                                 claudeMdFile = new File(testPlanDir, "CLAUDE.md");
-                                Files.write(claudeMdFile.toPath(),
-                                        systemPrompt.getBytes(StandardCharsets.UTF_8));
-                                log.info("Wrote CLAUDE.md to: {}", claudeMdFile.getAbsolutePath());
+                                Files.write(claudeMdFile.toPath(), contextBytes);
+                                log.info("Wrote CLAUDE.md to: {} (redaction enabled={})",
+                                        claudeMdFile.getAbsolutePath(),
+                                        org.qainsights.jmeter.ai.security.SecretRedactor.isEnabled());
 
                                 // AWS Kiro (and other agents) read AGENTS.md / KIRO.md
                                 // instead of CLAUDE.md, so mirror the same context there.
-                                Files.write(new File(testPlanDir, "AGENTS.md").toPath(),
-                                        systemPrompt.getBytes(StandardCharsets.UTF_8));
-                                Files.write(new File(testPlanDir, "KIRO.md").toPath(),
-                                        systemPrompt.getBytes(StandardCharsets.UTF_8));
+                                Files.write(new File(testPlanDir, "AGENTS.md").toPath(), contextBytes);
+                                Files.write(new File(testPlanDir, "KIRO.md").toPath(), contextBytes);
                             } catch (Exception e) {
                                 log.warn("Could not write CLAUDE.md", e);
                                 claudeMdFile = null;

--- a/src/main/java/org/qainsights/jmeter/ai/claudecode/ClaudeCodePanel.java
+++ b/src/main/java/org/qainsights/jmeter/ai/claudecode/ClaudeCodePanel.java
@@ -116,6 +116,10 @@ public class ClaudeCodePanel extends JPanel {
         if (antigravity.isEnabled() && antigravity.detect())
             available.add(antigravity);
 
+        AiCliAdapter kiro = new KiroCliAdapter();
+        if (kiro.isEnabled() && kiro.detect())
+            available.add(kiro);
+
         return available;
     }
 
@@ -262,6 +266,13 @@ public class ClaudeCodePanel extends JPanel {
                                 Files.write(claudeMdFile.toPath(),
                                         systemPrompt.getBytes(StandardCharsets.UTF_8));
                                 log.info("Wrote CLAUDE.md to: {}", claudeMdFile.getAbsolutePath());
+
+                                // AWS Kiro (and other agents) read AGENTS.md / KIRO.md
+                                // instead of CLAUDE.md, so mirror the same context there.
+                                Files.write(new File(testPlanDir, "AGENTS.md").toPath(),
+                                        systemPrompt.getBytes(StandardCharsets.UTF_8));
+                                Files.write(new File(testPlanDir, "KIRO.md").toPath(),
+                                        systemPrompt.getBytes(StandardCharsets.UTF_8));
                             } catch (Exception e) {
                                 log.warn("Could not write CLAUDE.md", e);
                                 claudeMdFile = null;

--- a/src/main/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapter.java
+++ b/src/main/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapter.java
@@ -97,6 +97,20 @@ public class KiroCliAdapter extends BaseCliAdapter {
         // from the working directory for test-plan context.
         List<String> command = super.buildCommand(workingDirectory);
         command.add("chat");
+
+        // Governed tool-trust policy. Defaults to read-only tools so the agent
+        // cannot mutate the test plan or filesystem without an explicit opt-in.
+        // Admins can lock either property via a managed user.properties.
+        if (AiConfig.getProperty("jmeter.ai.terminal.kiro.trust_all_tools", "false")
+                .equalsIgnoreCase("true")) {
+            command.add("--trust-all-tools");
+        } else {
+            String trustTools = AiConfig
+                    .getProperty("jmeter.ai.terminal.kiro.trust_tools", "read,grep,fs_read").trim();
+            if (!trustTools.isEmpty()) {
+                command.add("--trust-tools=" + trustTools);
+            }
+        }
         return command;
     }
 

--- a/src/main/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapter.java
+++ b/src/main/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapter.java
@@ -1,0 +1,117 @@
+package org.qainsights.jmeter.ai.claudecode;
+
+import org.qainsights.jmeter.ai.utils.AiConfig;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Adapter for the <strong>AWS Kiro</strong> agentic CLI ({@code kiro-cli}).
+ *
+ * <p>Kiro is not found by a plain {@code PATH} scan in two common situations on
+ * Windows: its binary is {@code kiro-cli.exe} (not {@code claude}/{@code codex}/…),
+ * and its installer adds {@code %USERPROFILE%\.kiro\bin} to the user PATH only for
+ * <em>newly</em> launched processes — an already-running JMeter never sees it.
+ * This adapter therefore resolves the binary in three steps:
+ *
+ * <ol>
+ *   <li>an explicit {@code jmeter.ai.terminal.kiro.path} override;</li>
+ *   <li>the system {@code PATH} ({@code kiro-cli}, then {@code kiro});</li>
+ *   <li>Kiro's well-known default install locations.</li>
+ * </ol>
+ *
+ * <p>The terminal launches Kiro interactively with {@code kiro-cli chat}; the test
+ * plan context is supplied via the {@code AGENTS.md}/{@code KIRO.md} files that
+ * {@code ClaudeCodePanel} writes into the working directory.
+ */
+public class KiroCliAdapter extends BaseCliAdapter {
+
+    @Override
+    public String getName() {
+        return "AWS Kiro";
+    }
+
+    @Override
+    public boolean detect() {
+        // 1) Explicit override wins.
+        String override = AiConfig.getProperty("jmeter.ai.terminal.kiro.path", "");
+        if (override != null && !override.trim().isEmpty()) {
+            File f = new File(expandHome(override.trim()));
+            if (f.isFile()) {
+                detectedPath = f.getAbsolutePath();
+                return true;
+            }
+        }
+
+        // 2) System PATH (handles kiro-cli and the shorter kiro alias).
+        String onPath = findOnPath("kiro-cli");
+        if (onPath == null) {
+            onPath = findOnPath("kiro");
+        }
+        if (onPath != null) {
+            detectedPath = onPath;
+            return true;
+        }
+
+        // 3) Kiro's default install locations (covers the stale-PATH case).
+        for (File candidate : defaultInstallCandidates()) {
+            if (candidate.isFile()) {
+                detectedPath = candidate.getAbsolutePath();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private List<File> defaultInstallCandidates() {
+        List<File> out = new ArrayList<>();
+        String home = System.getProperty("user.home", "");
+        boolean isWindows = System.getProperty("os.name", "").toLowerCase().contains("win");
+        if (isWindows) {
+            out.add(Paths.get(home, ".kiro", "bin", "kiro-cli.exe").toFile());
+            String localAppData = System.getenv("LOCALAPPDATA");
+            if (localAppData != null && !localAppData.trim().isEmpty()) {
+                out.add(Paths.get(localAppData, "Programs", "kiro", "bin", "kiro-cli.exe").toFile());
+                out.add(Paths.get(localAppData, "kiro", "bin", "kiro-cli.exe").toFile());
+            }
+        } else {
+            out.add(Paths.get(home, ".kiro", "bin", "kiro-cli").toFile());
+            out.add(new File("/usr/local/bin/kiro-cli"));
+            out.add(new File("/opt/kiro/bin/kiro-cli"));
+        }
+        return out;
+    }
+
+    private static String expandHome(String path) {
+        if (path.equals("~") || path.startsWith("~/") || path.startsWith("~\\")) {
+            return System.getProperty("user.home", "") + path.substring(1);
+        }
+        return path;
+    }
+
+    @Override
+    public List<String> buildCommand(String workingDirectory) {
+        // Launch Kiro's interactive terminal UI. Kiro reads AGENTS.md / KIRO.md
+        // from the working directory for test-plan context.
+        List<String> command = super.buildCommand(workingDirectory);
+        command.add("chat");
+        return command;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return AiConfig.getProperty("jmeter.ai.terminal.kiro.enabled", "true").equals("true");
+    }
+
+    @Override
+    public String defaultPrompt() {
+        return AiConfig.getProperty("jmeter.ai.terminal.kiro.prompt",
+                "You are an AI assistant integrated into Apache JMeter via the FeatherWand plugin. " +
+                        "You have access to the current JMeter test plan structure. " +
+                        "Help the user with performance testing tasks: analyzing and optimizing JMeter " +
+                        "test plans, creating test elements, debugging issues, performance best practices, " +
+                        "and writing/debugging Groovy and Java (JSR223) code.");
+    }
+}

--- a/src/main/java/org/qainsights/jmeter/ai/security/SecretRedactor.java
+++ b/src/main/java/org/qainsights/jmeter/ai/security/SecretRedactor.java
@@ -1,0 +1,104 @@
+package org.qainsights.jmeter.ai.security;
+
+import org.qainsights.jmeter.ai.utils.AiConfig;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Masks secrets and credentials before any test-plan context is handed to an AI
+ * CLI (written to {@code CLAUDE.md} / {@code AGENTS.md} / {@code KIRO.md}).
+ *
+ * <p>JMeter test plans routinely embed passwords, bearer tokens, API keys, and
+ * other secrets in sampler fields, HTTP headers, and CSV data. Sending those to
+ * an external agent is the single biggest blocker to enterprise adoption, so
+ * redaction is <strong>enabled by default</strong> and can only be turned off
+ * explicitly via {@code jmeter.ai.security.redaction.enabled=false}.
+ *
+ * <p>Redaction is intentionally conservative-to-aggressive: over-masking is safe,
+ * under-masking leaks. Three layers are applied:
+ * <ol>
+ *   <li><b>Key-based</b> — any {@code name = value} / {@code "name": "value"} /
+ *       {@code name=value} whose key looks like a credential.</li>
+ *   <li><b>Bearer tokens</b> — {@code Authorization: Bearer &lt;token&gt;}.</li>
+ *   <li><b>JWTs</b> — {@code eyJ...}.{...}.{...} anywhere in the text.</li>
+ * </ol>
+ */
+public final class SecretRedactor {
+
+    public static final String MASK = "***REDACTED***";
+
+    private static final String ENABLED_PROP = "jmeter.ai.security.redaction.enabled";
+    /** Comma-separated extra key fragments to treat as secret, e.g. {@code pin,otp}. */
+    private static final String EXTRA_KEYS_PROP = "jmeter.ai.security.redaction.extra_keys";
+
+    private static final String BASE_KEYS =
+            "password|passwd|pwd|secret|secret[_-]?key|token|auth[_-]?token|api[_-]?key|apikey|"
+                    + "access[_-]?key|client[_-]?secret|authorization|bearer|credential|private[_-]?key|"
+                    + "connection[_-]?string|session[_-]?id|cookie";
+
+    private static final Pattern BEARER =
+            Pattern.compile("(?i)(bearer\\s+)[A-Za-z0-9._~+/=\\-]{6,}");
+    private static final Pattern JWT =
+            Pattern.compile("eyJ[A-Za-z0-9_-]{6,}\\.[A-Za-z0-9_-]{4,}\\.[A-Za-z0-9_-]{4,}");
+
+    private SecretRedactor() {
+    }
+
+    /** @return {@code true} unless an admin has explicitly disabled redaction. */
+    public static boolean isEnabled() {
+        return AiConfig.getProperty(ENABLED_PROP, "true").equalsIgnoreCase("true");
+    }
+
+    /**
+     * Redact secrets from {@code text}. Returns the input unchanged if redaction
+     * is disabled or the input is null/empty.
+     */
+    public static String redact(String text) {
+        if (text == null || text.isEmpty() || !isEnabled()) {
+            return text;
+        }
+        String result = text;
+
+        // 1) Key-based: <key><sep><value>. Keys may be dotted (e.g. HTTPSampler.password).
+        Pattern keyValue = Pattern.compile(
+                "(?i)([\\w.\\-]*(?:" + keywordAlternation() + ")[\\w.\\-]*[\"']?\\s*[:=]\\s*[\"']?)"
+                        + "([^\"'\\r\\n,;}<>&]+)");
+        result = replaceGroup2(result, keyValue);
+
+        // 2) Authorization: Bearer <token>
+        result = BEARER.matcher(result).replaceAll("$1" + Matcher.quoteReplacement(MASK));
+
+        // 3) Standalone JWTs
+        result = JWT.matcher(result).replaceAll(Matcher.quoteReplacement(MASK));
+
+        return result;
+    }
+
+    private static String keywordAlternation() {
+        String extra = AiConfig.getProperty(EXTRA_KEYS_PROP, "").trim();
+        if (extra.isEmpty()) {
+            return BASE_KEYS;
+        }
+        // Escape and OR-in the operator-supplied fragments.
+        StringBuilder sb = new StringBuilder(BASE_KEYS);
+        for (String frag : extra.split(",")) {
+            String f = frag.trim();
+            if (!f.isEmpty()) {
+                sb.append('|').append(Pattern.quote(f));
+            }
+        }
+        return sb.toString();
+    }
+
+    /** Replace capture group 2 (the value) with the mask, keeping the key prefix. */
+    private static String replaceGroup2(String input, Pattern pattern) {
+        Matcher m = pattern.matcher(input);
+        StringBuffer out = new StringBuffer();
+        while (m.find()) {
+            m.appendReplacement(out, Matcher.quoteReplacement(m.group(1) + MASK));
+        }
+        m.appendTail(out);
+        return out.toString();
+    }
+}

--- a/src/test/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapterTest.java
+++ b/src/test/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapterTest.java
@@ -1,0 +1,96 @@
+package org.qainsights.jmeter.ai.claudecode;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link KiroCliAdapter}.
+ * <p>
+ * The protected {@link BaseCliAdapter#findOnPath(String)} is overridden in
+ * anonymous subclasses so tests never invoke a real system process.
+ */
+class KiroCliAdapterTest {
+
+    // ── getName ────────────────────────────────────────────────────────────────
+
+    @Test
+    void getName_returnsAwsKiro() {
+        assertEquals("AWS Kiro", new KiroCliAdapter().getName());
+    }
+
+    @Test
+    void toString_returnsAwsKiro() {
+        assertEquals("AWS Kiro", new KiroCliAdapter().toString());
+    }
+
+    // ── getBinaryPath before detect ────────────────────────────────────────────
+
+    @Test
+    void getBinaryPath_returnsNullBeforeDetect() {
+        assertNull(new KiroCliAdapter().getBinaryPath());
+    }
+
+    // ── detect ─────────────────────────────────────────────────────────────────
+
+    @Test
+    void detect_whenKiroCliOnPath_returnsTrueAndSetsPath() {
+        KiroCliAdapter adapter = new KiroCliAdapter() {
+            @Override
+            protected String findOnPath(String binaryName) {
+                return "kiro-cli".equals(binaryName) ? "/home/me/.kiro/bin/kiro-cli" : null;
+            }
+        };
+        assertTrue(adapter.detect());
+        assertEquals("/home/me/.kiro/bin/kiro-cli", adapter.getBinaryPath());
+    }
+
+    @Test
+    void detect_prefersKiroCliOverShortKiroAlias() {
+        String[] firstQueried = {null};
+        KiroCliAdapter adapter = new KiroCliAdapter() {
+            @Override
+            protected String findOnPath(String binaryName) {
+                if (firstQueried[0] == null) {
+                    firstQueried[0] = binaryName;
+                }
+                return null;
+            }
+        };
+        adapter.detect();
+        assertEquals("kiro-cli", firstQueried[0]);
+    }
+
+    @Test
+    void detect_fallsBackToKiroAliasWhenKiroCliMissing() {
+        KiroCliAdapter adapter = new KiroCliAdapter() {
+            @Override
+            protected String findOnPath(String binaryName) {
+                return "kiro".equals(binaryName) ? "/usr/local/bin/kiro" : null;
+            }
+        };
+        assertTrue(adapter.detect());
+        assertEquals("/usr/local/bin/kiro", adapter.getBinaryPath());
+    }
+
+    // ── buildCommand ───────────────────────────────────────────────────────────
+
+    @Test
+    void buildCommand_afterDetect_appendsChatSubcommand() {
+        KiroCliAdapter adapter = new KiroCliAdapter() {
+            @Override
+            protected String findOnPath(String binaryName) {
+                return "/usr/local/bin/kiro-cli";
+            }
+        };
+        adapter.detect();
+
+        List<String> command = adapter.buildCommand(null);
+
+        assertEquals(2, command.size());
+        assertEquals("/usr/local/bin/kiro-cli", command.get(0));
+        assertEquals("chat", command.get(1));
+    }
+}

--- a/src/test/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapterTest.java
+++ b/src/test/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapterTest.java
@@ -1,7 +1,11 @@
 package org.qainsights.jmeter.ai.claudecode;
 
+import org.apache.jmeter.util.JMeterUtils;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -13,6 +17,16 @@ import static org.junit.jupiter.api.Assertions.*;
  * anonymous subclasses so tests never invoke a real system process.
  */
 class KiroCliAdapterTest {
+
+    @BeforeAll
+    static void initJMeterProperties() throws IOException {
+        // setProperty needs an initialized properties object; load an empty one.
+        if (JMeterUtils.getJMeterProperties() == null) {
+            File tmp = File.createTempFile("jmeter-test", ".properties");
+            tmp.deleteOnExit();
+            JMeterUtils.loadJMeterProperties(tmp.getAbsolutePath());
+        }
+    }
 
     // ── getName ────────────────────────────────────────────────────────────────
 
@@ -79,18 +93,62 @@ class KiroCliAdapterTest {
 
     @Test
     void buildCommand_afterDetect_appendsChatSubcommand() {
-        KiroCliAdapter adapter = new KiroCliAdapter() {
-            @Override
-            protected String findOnPath(String binaryName) {
-                return "/usr/local/bin/kiro-cli";
-            }
-        };
-        adapter.detect();
+        KiroCliAdapter adapter = detectedAdapter("/usr/local/bin/kiro-cli");
 
         List<String> command = adapter.buildCommand(null);
 
-        assertEquals(2, command.size());
         assertEquals("/usr/local/bin/kiro-cli", command.get(0));
         assertEquals("chat", command.get(1));
+    }
+
+    // ── tool-trust policy ──────────────────────────────────────────────────────
+
+    @Test
+    void buildCommand_byDefault_restrictsToReadOnlyTrustedTools() {
+        KiroCliAdapter adapter = detectedAdapter("/usr/local/bin/kiro-cli");
+
+        List<String> command = adapter.buildCommand(null);
+
+        assertTrue(command.contains("--trust-tools=read,grep,fs_read"),
+                "default policy must trust only read-only tools: " + command);
+        assertFalse(command.contains("--trust-all-tools"));
+    }
+
+    @Test
+    void buildCommand_whenTrustAllToolsEnabled_usesTrustAllFlag() {
+        withProperty("jmeter.ai.terminal.kiro.trust_all_tools", "true", () -> {
+            List<String> command = detectedAdapter("/usr/local/bin/kiro-cli").buildCommand(null);
+            assertTrue(command.contains("--trust-all-tools"), command.toString());
+            assertFalse(command.stream().anyMatch(s -> s.startsWith("--trust-tools=")));
+        });
+    }
+
+    @Test
+    void buildCommand_whenTrustToolsBlank_omitsTrustFlag() {
+        withProperty("jmeter.ai.terminal.kiro.trust_tools", "", () -> {
+            List<String> command = detectedAdapter("/usr/local/bin/kiro-cli").buildCommand(null);
+            assertFalse(command.stream().anyMatch(s -> s.startsWith("--trust-tools")), command.toString());
+        });
+    }
+
+    private static KiroCliAdapter detectedAdapter(String binary) {
+        KiroCliAdapter adapter = new KiroCliAdapter() {
+            @Override
+            protected String findOnPath(String binaryName) {
+                return binary;
+            }
+        };
+        adapter.detect();
+        return adapter;
+    }
+
+    private static void withProperty(String key, String value, Runnable body) {
+        String prev = org.apache.jmeter.util.JMeterUtils.getProperty(key);
+        try {
+            org.apache.jmeter.util.JMeterUtils.setProperty(key, value);
+            body.run();
+        } finally {
+            org.apache.jmeter.util.JMeterUtils.setProperty(key, prev == null ? "" : prev);
+        }
     }
 }

--- a/src/test/java/org/qainsights/jmeter/ai/security/SecretRedactorTest.java
+++ b/src/test/java/org/qainsights/jmeter/ai/security/SecretRedactorTest.java
@@ -1,0 +1,67 @@
+package org.qainsights.jmeter.ai.security;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link SecretRedactor}. Redaction is on by default (no JMeter
+ * properties loaded), so these exercise the default-enabled behaviour.
+ */
+class SecretRedactorTest {
+
+    @Test
+    void masksPropertyStyleSecretButKeepsKey() {
+        String in = "  | HTTPSampler.password = s3cr3tV4lue\n  | HTTPSampler.path = /api/login";
+        String out = SecretRedactor.redact(in);
+
+        assertFalse(out.contains("s3cr3tV4lue"), out);
+        assertTrue(out.contains("HTTPSampler.password = " + SecretRedactor.MASK), out);
+        // Non-secret values are untouched.
+        assertTrue(out.contains("/api/login"), out);
+    }
+
+    @Test
+    void masksJsonStyleTokenField() {
+        String in = "{\"api_key\":\"AKIA1234567890\",\"region\":\"us-east-1\"}";
+        String out = SecretRedactor.redact(in);
+
+        assertFalse(out.contains("AKIA1234567890"), out);
+        assertTrue(out.contains("us-east-1"), out);
+    }
+
+    @Test
+    void masksBearerToken() {
+        String in = "Authorization: Bearer abc123DEF456ghi789";
+        String out = SecretRedactor.redact(in);
+
+        assertFalse(out.contains("abc123DEF456ghi789"), out);
+        assertTrue(out.contains(SecretRedactor.MASK), out);
+    }
+
+    @Test
+    void masksStandaloneJwt() {
+        String in = "cookie value eyJhbGciOiJIUzI1Ni19.eyJzdWIiOiIxMjM0NTY.SflKxwRJSMeKKF2QT4";
+        String out = SecretRedactor.redact(in);
+
+        assertFalse(out.contains("eyJhbGciOiJIUzI1Ni19"), out);
+        assertTrue(out.contains(SecretRedactor.MASK), out);
+    }
+
+    @Test
+    void leavesBenignTextUnchanged() {
+        String in = "[ThreadGroup] Login Flow\n  | num_threads = 100\n  | ramp_time = 30";
+        assertEquals(in, SecretRedactor.redact(in));
+    }
+
+    @Test
+    void handlesNullAndEmpty() {
+        assertNull(SecretRedactor.redact(null));
+        assertEquals("", SecretRedactor.redact(""));
+    }
+
+    @Test
+    void isEnabledByDefault() {
+        assertTrue(SecretRedactor.isEnabled());
+    }
+}


### PR DESCRIPTION
## Summary

Enterprise hardening for the AI terminal. Closes the two biggest exposure points before any test-plan context is handed to an external AI CLI: **secret leakage** and **unrestricted tool access**.

> Note: this branch stacks on #61 (the Kiro adapter); the first commit is that PR. Please merge #61 first, or review the second commit `feat(security): …` in isolation.

## 1. Context redaction (default ON)

JMeter test plans routinely contain passwords, bearer tokens, API keys, and PII in sampler fields, HTTP headers, and CSV data. Today the serialized plan is written verbatim to `CLAUDE.md` / `AGENTS.md` / `KIRO.md` and sent to the CLI.

- New **`SecretRedactor`** masks credentials via three layers — key-based (`*.password`, `api_key`, `authorization`, …), `Bearer <token>`, and standalone JWTs (`eyJ…`).
- Applied to the context in `ClaudeCodePanel` before the files are written, so secrets never leave JMeter. Benefits **all** CLIs (Claude Code, Codex, OpenCode, Kiro, …), not just Kiro.
- Config: `jmeter.ai.security.redaction.enabled` (default `true`), `jmeter.ai.security.redaction.extra_keys` (e.g. `pin,otp,ssn`).

## 2. Governed tool-trust policy for Kiro

- `KiroCliAdapter` now launches with **`--trust-tools=read,grep,fs_read`** by default (read-only), so the agent cannot mutate the test plan or filesystem without an explicit opt-in.
- Admins can lock `jmeter.ai.terminal.kiro.trust_tools`, or set `jmeter.ai.terminal.kiro.trust_all_tools=true`, via a managed `user.properties`.

## Testing

`mvn clean test` → **BUILD SUCCESS**. New `SecretRedactorTest` (7) covers masking of property-style, JSON, bearer, and JWT secrets plus benign-text pass-through; expanded `KiroCliAdapterTest` (10) covers the default read-only policy, `--trust-all-tools`, and blank-policy omission. Java 8 compatible.

## Out of scope (follow-ups discussed)

Audit logging, MCP wiring, headless/CI mode, and spec-driven plan generation are intentionally left for separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds secret redaction to the exported test-plan context and sets Kiro to read-only tools by default. This reduces credential leaks and prevents unintended plan/filesystem changes.

- **New Features**
  - Default-on redaction via `SecretRedactor`: masks passwords, tokens (Bearer/JWT), and common credential keys.
  - Redaction applied when writing `CLAUDE.md`, `AGENTS.md`, and `KIRO.md`. Configure with `jmeter.ai.security.redaction.enabled` and `jmeter.ai.security.redaction.extra_keys`.
  - Kiro launches with `--trust-tools=read,grep,fs_read` by default. Opt in with `jmeter.ai.terminal.kiro.trust_all_tools=true` or customize `jmeter.ai.terminal.kiro.trust_tools`.

- **Migration**
  - No changes required; safe defaults apply.
  - Only disable redaction (`jmeter.ai.security.redaction.enabled=false`) or enable broader tool access in trusted environments.

<sup>Written for commit f4347b8df889d7e92714d75e8e2168e541e72edc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/QAInsights/jmeter-ai/pull/62?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

