### PR TITLE
feat(security): audit log for AI CLI invocations

### DIFF
--- a/jmeter-ai-sample.properties
+++ b/jmeter-ai-sample.properties
@@ -44,6 +44,23 @@ Analyzing and optimizing JMeter test plans \
 - JMeter scripting and configuration \
 - Write, debug, and test Java code \
 - Write, debug, and test Groovy script
+# AWS Kiro CLI (kiro-cli) - enabled by default
+jmeter.ai.terminal.kiro.enabled=true
+# Optional: full path to the kiro-cli binary. Leave blank to auto-detect on PATH
+# and in Kiro's default install location.
+# Windows example: C:\Users\YOUR_USER_NAME\.kiro\bin\kiro-cli.exe
+# Linux/macOS example: /home/YOUR_USER_NAME/.kiro/bin/kiro-cli
+jmeter.ai.terminal.kiro.path=
+jmeter.ai.terminal.kiro.prompt=You are an AI assistant integrated into Apache JMeter via the FeatherWand plugin. \
+You have access to the current JMeter test plan structure. \
+Help the user with performance testing tasks including: \
+Analyzing and optimizing JMeter test plans \
+- Creating new test elements (Thread Groups, Samplers, Assertions, etc.) \
+- Debugging test plan issues \
+- Performance testing best practices \
+- JMeter scripting and configuration \
+- Write, debug, and test Java code \
+- Write, debug, and test Groovy script
 # Antigravity CLI (Google) - disabled by default
 jmeter.ai.terminal.antigravity.enabled=false
 jmeter.ai.terminal.antigravity.prompt=You are an AI assistant integrated into Apache JMeter via the FeatherWand plugin. \

--- a/jmeter-ai-sample.properties
+++ b/jmeter-ai-sample.properties
@@ -35,6 +35,13 @@ jmeter.ai.security.redaction.enabled=true
 # Optional extra key fragments to redact, comma-separated (e.g. pin,otp,ssn)
 jmeter.ai.security.redaction.extra_keys=
 
+# Audit log: append one JSON line per AI CLI launch (user, host, CLI, command
+# flags, working dir, redaction state, and a SHA-256 of the shared context).
+# The content itself is never logged - only its hash - so the trail is safe to
+# retain. Default file: <JMETER_HOME>/logs/jmeter-ai-audit.log
+jmeter.ai.security.audit.enabled=true
+jmeter.ai.security.audit.file=
+
 ##### AI Terminal Settings #####
 jmeter.ai.terminal.claudecode.enabled=true
 # Full path containing the claude executable

--- a/jmeter-ai-sample.properties
+++ b/jmeter-ai-sample.properties
@@ -27,6 +27,14 @@ jmeter.ai.correlation.min_value_length=3
 # Higher values require more randomness. Set to 0 to disable entropy-based detection.
 jmeter.ai.correlation.min_entropy=2.8
 
+##### AI Security / Governance #####
+# Redact secrets (passwords, tokens, API keys, bearer/JWT) from the test-plan
+# context before it is written to CLAUDE.md / AGENTS.md / KIRO.md and sent to any
+# AI CLI. Strongly recommended; set to false only in trusted, offline setups.
+jmeter.ai.security.redaction.enabled=true
+# Optional extra key fragments to redact, comma-separated (e.g. pin,otp,ssn)
+jmeter.ai.security.redaction.extra_keys=
+
 ##### AI Terminal Settings #####
 jmeter.ai.terminal.claudecode.enabled=true
 # Full path containing the claude executable
@@ -51,6 +59,11 @@ jmeter.ai.terminal.kiro.enabled=true
 # Windows example: C:\Users\YOUR_USER_NAME\.kiro\bin\kiro-cli.exe
 # Linux/macOS example: /home/YOUR_USER_NAME/.kiro/bin/kiro-cli
 jmeter.ai.terminal.kiro.path=
+# Tool-trust policy. Defaults to read-only tools so the agent cannot mutate the
+# test plan or filesystem without an explicit opt-in. Admins can lock this in a
+# managed user.properties. Set trust_all_tools=true only for trusted operators.
+jmeter.ai.terminal.kiro.trust_tools=read,grep,fs_read
+jmeter.ai.terminal.kiro.trust_all_tools=false
 jmeter.ai.terminal.kiro.prompt=You are an AI assistant integrated into Apache JMeter via the FeatherWand plugin. \
 You have access to the current JMeter test plan structure. \
 Help the user with performance testing tasks including: \

--- a/src/main/java/org/qainsights/jmeter/ai/claudecode/ClaudeCodePanel.java
+++ b/src/main/java/org/qainsights/jmeter/ai/claudecode/ClaudeCodePanel.java
@@ -289,6 +289,15 @@ public class ClaudeCodePanel extends JPanel {
                                 ? selectedCli.buildCommand(testPlanDir)
                                 : new ArrayList<>(Arrays.asList(claudeBinary));
 
+                        // Audit trail: record who launched which CLI, with what flags,
+                        // and a hash of the (redacted) context that was shared.
+                        org.qainsights.jmeter.ai.security.AuditLogger.recordLaunch(
+                                selectedCli != null ? selectedCli.getName() : "unknown",
+                                claudeBinary,
+                                command,
+                                testPlanDir,
+                                org.qainsights.jmeter.ai.security.SecretRedactor.redact(systemPrompt));
+
                         // Set up environment
                         Map<String, String> env = new HashMap<>(System.getenv());
                         env.put("TERM", "xterm-256color");

--- a/src/main/java/org/qainsights/jmeter/ai/claudecode/ClaudeCodePanel.java
+++ b/src/main/java/org/qainsights/jmeter/ai/claudecode/ClaudeCodePanel.java
@@ -262,17 +262,22 @@ public class ClaudeCodePanel extends JPanel {
                         // by PtyProcessBuilder, causing stray text to be sent as user input)
                         if (testPlanDir != null) {
                             try {
+                                // Redact secrets (passwords, tokens, API keys) before any
+                                // context leaves JMeter for an external AI CLI. Enabled by
+                                // default; see jmeter.ai.security.redaction.enabled.
+                                byte[] contextBytes = org.qainsights.jmeter.ai.security.SecretRedactor
+                                        .redact(systemPrompt).getBytes(StandardCharsets.UTF_8);
+
                                 claudeMdFile = new File(testPlanDir, "CLAUDE.md");
-                                Files.write(claudeMdFile.toPath(),
-                                        systemPrompt.getBytes(StandardCharsets.UTF_8));
-                                log.info("Wrote CLAUDE.md to: {}", claudeMdFile.getAbsolutePath());
+                                Files.write(claudeMdFile.toPath(), contextBytes);
+                                log.info("Wrote CLAUDE.md to: {} (redaction enabled={})",
+                                        claudeMdFile.getAbsolutePath(),
+                                        org.qainsights.jmeter.ai.security.SecretRedactor.isEnabled());
 
                                 // AWS Kiro (and other agents) read AGENTS.md / KIRO.md
                                 // instead of CLAUDE.md, so mirror the same context there.
-                                Files.write(new File(testPlanDir, "AGENTS.md").toPath(),
-                                        systemPrompt.getBytes(StandardCharsets.UTF_8));
-                                Files.write(new File(testPlanDir, "KIRO.md").toPath(),
-                                        systemPrompt.getBytes(StandardCharsets.UTF_8));
+                                Files.write(new File(testPlanDir, "AGENTS.md").toPath(), contextBytes);
+                                Files.write(new File(testPlanDir, "KIRO.md").toPath(), contextBytes);
                             } catch (Exception e) {
                                 log.warn("Could not write CLAUDE.md", e);
                                 claudeMdFile = null;

--- a/src/main/java/org/qainsights/jmeter/ai/claudecode/ClaudeCodePanel.java
+++ b/src/main/java/org/qainsights/jmeter/ai/claudecode/ClaudeCodePanel.java
@@ -116,6 +116,10 @@ public class ClaudeCodePanel extends JPanel {
         if (antigravity.isEnabled() && antigravity.detect())
             available.add(antigravity);
 
+        AiCliAdapter kiro = new KiroCliAdapter();
+        if (kiro.isEnabled() && kiro.detect())
+            available.add(kiro);
+
         return available;
     }
 
@@ -262,6 +266,13 @@ public class ClaudeCodePanel extends JPanel {
                                 Files.write(claudeMdFile.toPath(),
                                         systemPrompt.getBytes(StandardCharsets.UTF_8));
                                 log.info("Wrote CLAUDE.md to: {}", claudeMdFile.getAbsolutePath());
+
+                                // AWS Kiro (and other agents) read AGENTS.md / KIRO.md
+                                // instead of CLAUDE.md, so mirror the same context there.
+                                Files.write(new File(testPlanDir, "AGENTS.md").toPath(),
+                                        systemPrompt.getBytes(StandardCharsets.UTF_8));
+                                Files.write(new File(testPlanDir, "KIRO.md").toPath(),
+                                        systemPrompt.getBytes(StandardCharsets.UTF_8));
                             } catch (Exception e) {
                                 log.warn("Could not write CLAUDE.md", e);
                                 claudeMdFile = null;

--- a/src/main/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapter.java
+++ b/src/main/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapter.java
@@ -97,6 +97,20 @@ public class KiroCliAdapter extends BaseCliAdapter {
         // from the working directory for test-plan context.
         List<String> command = super.buildCommand(workingDirectory);
         command.add("chat");
+
+        // Governed tool-trust policy. Defaults to read-only tools so the agent
+        // cannot mutate the test plan or filesystem without an explicit opt-in.
+        // Admins can lock either property via a managed user.properties.
+        if (AiConfig.getProperty("jmeter.ai.terminal.kiro.trust_all_tools", "false")
+                .equalsIgnoreCase("true")) {
+            command.add("--trust-all-tools");
+        } else {
+            String trustTools = AiConfig
+                    .getProperty("jmeter.ai.terminal.kiro.trust_tools", "read,grep,fs_read").trim();
+            if (!trustTools.isEmpty()) {
+                command.add("--trust-tools=" + trustTools);
+            }
+        }
         return command;
     }
 

--- a/src/main/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapter.java
+++ b/src/main/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapter.java
@@ -1,0 +1,117 @@
+package org.qainsights.jmeter.ai.claudecode;
+
+import org.qainsights.jmeter.ai.utils.AiConfig;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Adapter for the <strong>AWS Kiro</strong> agentic CLI ({@code kiro-cli}).
+ *
+ * <p>Kiro is not found by a plain {@code PATH} scan in two common situations on
+ * Windows: its binary is {@code kiro-cli.exe} (not {@code claude}/{@code codex}/…),
+ * and its installer adds {@code %USERPROFILE%\.kiro\bin} to the user PATH only for
+ * <em>newly</em> launched processes — an already-running JMeter never sees it.
+ * This adapter therefore resolves the binary in three steps:
+ *
+ * <ol>
+ *   <li>an explicit {@code jmeter.ai.terminal.kiro.path} override;</li>
+ *   <li>the system {@code PATH} ({@code kiro-cli}, then {@code kiro});</li>
+ *   <li>Kiro's well-known default install locations.</li>
+ * </ol>
+ *
+ * <p>The terminal launches Kiro interactively with {@code kiro-cli chat}; the test
+ * plan context is supplied via the {@code AGENTS.md}/{@code KIRO.md} files that
+ * {@code ClaudeCodePanel} writes into the working directory.
+ */
+public class KiroCliAdapter extends BaseCliAdapter {
+
+    @Override
+    public String getName() {
+        return "AWS Kiro";
+    }
+
+    @Override
+    public boolean detect() {
+        // 1) Explicit override wins.
+        String override = AiConfig.getProperty("jmeter.ai.terminal.kiro.path", "");
+        if (override != null && !override.trim().isEmpty()) {
+            File f = new File(expandHome(override.trim()));
+            if (f.isFile()) {
+                detectedPath = f.getAbsolutePath();
+                return true;
+            }
+        }
+
+        // 2) System PATH (handles kiro-cli and the shorter kiro alias).
+        String onPath = findOnPath("kiro-cli");
+        if (onPath == null) {
+            onPath = findOnPath("kiro");
+        }
+        if (onPath != null) {
+            detectedPath = onPath;
+            return true;
+        }
+
+        // 3) Kiro's default install locations (covers the stale-PATH case).
+        for (File candidate : defaultInstallCandidates()) {
+            if (candidate.isFile()) {
+                detectedPath = candidate.getAbsolutePath();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private List<File> defaultInstallCandidates() {
+        List<File> out = new ArrayList<>();
+        String home = System.getProperty("user.home", "");
+        boolean isWindows = System.getProperty("os.name", "").toLowerCase().contains("win");
+        if (isWindows) {
+            out.add(Paths.get(home, ".kiro", "bin", "kiro-cli.exe").toFile());
+            String localAppData = System.getenv("LOCALAPPDATA");
+            if (localAppData != null && !localAppData.trim().isEmpty()) {
+                out.add(Paths.get(localAppData, "Programs", "kiro", "bin", "kiro-cli.exe").toFile());
+                out.add(Paths.get(localAppData, "kiro", "bin", "kiro-cli.exe").toFile());
+            }
+        } else {
+            out.add(Paths.get(home, ".kiro", "bin", "kiro-cli").toFile());
+            out.add(new File("/usr/local/bin/kiro-cli"));
+            out.add(new File("/opt/kiro/bin/kiro-cli"));
+        }
+        return out;
+    }
+
+    private static String expandHome(String path) {
+        if (path.equals("~") || path.startsWith("~/") || path.startsWith("~\\")) {
+            return System.getProperty("user.home", "") + path.substring(1);
+        }
+        return path;
+    }
+
+    @Override
+    public List<String> buildCommand(String workingDirectory) {
+        // Launch Kiro's interactive terminal UI. Kiro reads AGENTS.md / KIRO.md
+        // from the working directory for test-plan context.
+        List<String> command = super.buildCommand(workingDirectory);
+        command.add("chat");
+        return command;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return AiConfig.getProperty("jmeter.ai.terminal.kiro.enabled", "true").equals("true");
+    }
+
+    @Override
+    public String defaultPrompt() {
+        return AiConfig.getProperty("jmeter.ai.terminal.kiro.prompt",
+                "You are an AI assistant integrated into Apache JMeter via the FeatherWand plugin. " +
+                        "You have access to the current JMeter test plan structure. " +
+                        "Help the user with performance testing tasks: analyzing and optimizing JMeter " +
+                        "test plans, creating test elements, debugging issues, performance best practices, " +
+                        "and writing/debugging Groovy and Java (JSR223) code.");
+    }
+}

--- a/src/main/java/org/qainsights/jmeter/ai/security/AuditLogger.java
+++ b/src/main/java/org/qainsights/jmeter/ai/security/AuditLogger.java
@@ -1,0 +1,189 @@
+package org.qainsights.jmeter.ai.security;
+
+import org.qainsights.jmeter.ai.utils.AiConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.security.MessageDigest;
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Append-only audit trail for AI CLI invocations.
+ *
+ * <p>Enterprises need to answer "who sent what to which AI, and when" for
+ * security reviews and compliance. Every time the embedded terminal launches an
+ * AI CLI, one JSON line is appended to the audit log capturing the actor, the
+ * CLI/binary, the resolved command (flags only — no secrets), the working
+ * directory, whether redaction was active, and a SHA-256 of the redacted context
+ * that was shared. The hash lets auditors prove exactly what was sent without
+ * the log itself ever storing the (potentially sensitive) content.
+ *
+ * <p>Enabled by default; controlled by {@code jmeter.ai.security.audit.enabled}.
+ * The destination is {@code jmeter.ai.security.audit.file}, defaulting to
+ * {@code <JMETER_HOME>/logs/jmeter-ai-audit.log} (or {@code ~/.jmeter-ai-audit.log}).
+ */
+public final class AuditLogger {
+
+    private static final Logger log = LoggerFactory.getLogger(AuditLogger.class);
+
+    private static final String ENABLED_PROP = "jmeter.ai.security.audit.enabled";
+    private static final String FILE_PROP = "jmeter.ai.security.audit.file";
+
+    private AuditLogger() {
+    }
+
+    public static boolean isEnabled() {
+        return AiConfig.getProperty(ENABLED_PROP, "true").equalsIgnoreCase("true");
+    }
+
+    /**
+     * Record one AI CLI launch. Never throws — auditing must not break the
+     * terminal; failures are logged via slf4j instead.
+     *
+     * @param cliName       display name of the CLI (e.g. "AWS Kiro")
+     * @param binaryPath    resolved binary path
+     * @param command       full argv (flags only; no secret values)
+     * @param workingDir    working directory shared with the CLI (may be null)
+     * @param sharedContext the redacted context text written for the CLI (may be null)
+     */
+    public static void recordLaunch(String cliName, String binaryPath, List<String> command,
+                                    String workingDir, String sharedContext) {
+        if (!isEnabled()) {
+            return;
+        }
+        try {
+            StringBuilder json = new StringBuilder(512);
+            json.append('{');
+            field(json, "timestamp", Instant.now().toString());
+            json.append(',');
+            field(json, "event", "ai_cli_launch");
+            json.append(',');
+            field(json, "user", System.getProperty("user.name", "unknown"));
+            json.append(',');
+            field(json, "host", hostName());
+            json.append(',');
+            field(json, "cli", cliName);
+            json.append(',');
+            field(json, "binary", binaryPath);
+            json.append(',');
+            field(json, "command", command == null ? "" : String.join(" ", command));
+            json.append(',');
+            field(json, "workingDir", workingDir);
+            json.append(',');
+            field(json, "redactionEnabled", String.valueOf(SecretRedactor.isEnabled()));
+            json.append(',');
+            field(json, "contextSha256", sha256(sharedContext));
+            json.append(',');
+            field(json, "contextBytes",
+                    String.valueOf(sharedContext == null ? 0 : sharedContext.getBytes(StandardCharsets.UTF_8).length));
+            json.append('}');
+
+            String line = json.toString();
+            log.info("AI audit: {}", line);
+            Path target = resolveAuditFile();
+            Files.write(target, (line + System.lineSeparator()).getBytes(StandardCharsets.UTF_8),
+                    StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+        } catch (Exception e) {
+            // Auditing is best-effort; never disrupt the user's session.
+            log.warn("Could not write AI audit entry: {}", e.getMessage());
+        }
+    }
+
+    private static Path resolveAuditFile() throws IOException {
+        String configured = AiConfig.getProperty(FILE_PROP, "").trim();
+        if (!configured.isEmpty()) {
+            Path p = Paths.get(expandHome(configured));
+            ensureParent(p);
+            return p;
+        }
+        String jmeterHome = System.getProperty("jmeter.home",
+                System.getenv().getOrDefault("JMETER_HOME", ""));
+        if (jmeterHome != null && !jmeterHome.trim().isEmpty()) {
+            Path logsDir = Paths.get(jmeterHome, "logs");
+            try {
+                Files.createDirectories(logsDir);
+                return logsDir.resolve("jmeter-ai-audit.log");
+            } catch (IOException ignored) {
+                // fall through to home directory
+            }
+        }
+        return Paths.get(System.getProperty("user.home", "."), ".jmeter-ai-audit.log");
+    }
+
+    private static void ensureParent(Path p) throws IOException {
+        Path parent = p.getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+    }
+
+    private static String hostName() {
+        try {
+            return InetAddress.getLocalHost().getHostName();
+        } catch (Exception e) {
+            return "unknown";
+        }
+    }
+
+    static String sha256(String text) {
+        if (text == null) {
+            return "";
+        }
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] digest = md.digest(text.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder(digest.length * 2);
+            for (byte b : digest) {
+                sb.append(Character.forDigit((b >> 4) & 0xF, 16));
+                sb.append(Character.forDigit(b & 0xF, 16));
+            }
+            return sb.toString();
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+    private static String expandHome(String path) {
+        if (path.equals("~") || path.startsWith("~/") || path.startsWith("~\\")) {
+            return System.getProperty("user.home", "") + path.substring(1);
+        }
+        return path;
+    }
+
+    private static void field(StringBuilder sb, String key, String value) {
+        sb.append('"').append(key).append("\":\"").append(escape(value)).append('"');
+    }
+
+    /** Minimal JSON string escaping (dependency-free). */
+    static String escape(String s) {
+        if (s == null) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder(s.length() + 8);
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '"':  sb.append("\\\""); break;
+                case '\\': sb.append("\\\\"); break;
+                case '\n': sb.append("\\n");  break;
+                case '\r': sb.append("\\r");  break;
+                case '\t': sb.append("\\t");  break;
+                default:
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/org/qainsights/jmeter/ai/security/SecretRedactor.java
+++ b/src/main/java/org/qainsights/jmeter/ai/security/SecretRedactor.java
@@ -1,0 +1,104 @@
+package org.qainsights.jmeter.ai.security;
+
+import org.qainsights.jmeter.ai.utils.AiConfig;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Masks secrets and credentials before any test-plan context is handed to an AI
+ * CLI (written to {@code CLAUDE.md} / {@code AGENTS.md} / {@code KIRO.md}).
+ *
+ * <p>JMeter test plans routinely embed passwords, bearer tokens, API keys, and
+ * other secrets in sampler fields, HTTP headers, and CSV data. Sending those to
+ * an external agent is the single biggest blocker to enterprise adoption, so
+ * redaction is <strong>enabled by default</strong> and can only be turned off
+ * explicitly via {@code jmeter.ai.security.redaction.enabled=false}.
+ *
+ * <p>Redaction is intentionally conservative-to-aggressive: over-masking is safe,
+ * under-masking leaks. Three layers are applied:
+ * <ol>
+ *   <li><b>Key-based</b> — any {@code name = value} / {@code "name": "value"} /
+ *       {@code name=value} whose key looks like a credential.</li>
+ *   <li><b>Bearer tokens</b> — {@code Authorization: Bearer &lt;token&gt;}.</li>
+ *   <li><b>JWTs</b> — {@code eyJ...}.{...}.{...} anywhere in the text.</li>
+ * </ol>
+ */
+public final class SecretRedactor {
+
+    public static final String MASK = "***REDACTED***";
+
+    private static final String ENABLED_PROP = "jmeter.ai.security.redaction.enabled";
+    /** Comma-separated extra key fragments to treat as secret, e.g. {@code pin,otp}. */
+    private static final String EXTRA_KEYS_PROP = "jmeter.ai.security.redaction.extra_keys";
+
+    private static final String BASE_KEYS =
+            "password|passwd|pwd|secret|secret[_-]?key|token|auth[_-]?token|api[_-]?key|apikey|"
+                    + "access[_-]?key|client[_-]?secret|authorization|bearer|credential|private[_-]?key|"
+                    + "connection[_-]?string|session[_-]?id|cookie";
+
+    private static final Pattern BEARER =
+            Pattern.compile("(?i)(bearer\\s+)[A-Za-z0-9._~+/=\\-]{6,}");
+    private static final Pattern JWT =
+            Pattern.compile("eyJ[A-Za-z0-9_-]{6,}\\.[A-Za-z0-9_-]{4,}\\.[A-Za-z0-9_-]{4,}");
+
+    private SecretRedactor() {
+    }
+
+    /** @return {@code true} unless an admin has explicitly disabled redaction. */
+    public static boolean isEnabled() {
+        return AiConfig.getProperty(ENABLED_PROP, "true").equalsIgnoreCase("true");
+    }
+
+    /**
+     * Redact secrets from {@code text}. Returns the input unchanged if redaction
+     * is disabled or the input is null/empty.
+     */
+    public static String redact(String text) {
+        if (text == null || text.isEmpty() || !isEnabled()) {
+            return text;
+        }
+        String result = text;
+
+        // 1) Key-based: <key><sep><value>. Keys may be dotted (e.g. HTTPSampler.password).
+        Pattern keyValue = Pattern.compile(
+                "(?i)([\\w.\\-]*(?:" + keywordAlternation() + ")[\\w.\\-]*[\"']?\\s*[:=]\\s*[\"']?)"
+                        + "([^\"'\\r\\n,;}<>&]+)");
+        result = replaceGroup2(result, keyValue);
+
+        // 2) Authorization: Bearer <token>
+        result = BEARER.matcher(result).replaceAll("$1" + Matcher.quoteReplacement(MASK));
+
+        // 3) Standalone JWTs
+        result = JWT.matcher(result).replaceAll(Matcher.quoteReplacement(MASK));
+
+        return result;
+    }
+
+    private static String keywordAlternation() {
+        String extra = AiConfig.getProperty(EXTRA_KEYS_PROP, "").trim();
+        if (extra.isEmpty()) {
+            return BASE_KEYS;
+        }
+        // Escape and OR-in the operator-supplied fragments.
+        StringBuilder sb = new StringBuilder(BASE_KEYS);
+        for (String frag : extra.split(",")) {
+            String f = frag.trim();
+            if (!f.isEmpty()) {
+                sb.append('|').append(Pattern.quote(f));
+            }
+        }
+        return sb.toString();
+    }
+
+    /** Replace capture group 2 (the value) with the mask, keeping the key prefix. */
+    private static String replaceGroup2(String input, Pattern pattern) {
+        Matcher m = pattern.matcher(input);
+        StringBuffer out = new StringBuffer();
+        while (m.find()) {
+            m.appendReplacement(out, Matcher.quoteReplacement(m.group(1) + MASK));
+        }
+        m.appendTail(out);
+        return out.toString();
+    }
+}

--- a/src/test/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapterTest.java
+++ b/src/test/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapterTest.java
@@ -143,12 +143,18 @@ class KiroCliAdapterTest {
     }
 
     private static void withProperty(String key, String value, Runnable body) {
-        String prev = org.apache.jmeter.util.JMeterUtils.getProperty(key);
+        String prev = JMeterUtils.getProperty(key);
         try {
-            org.apache.jmeter.util.JMeterUtils.setProperty(key, value);
+            JMeterUtils.setProperty(key, value);
             body.run();
         } finally {
-            org.apache.jmeter.util.JMeterUtils.setProperty(key, prev == null ? "" : prev);
+            // Remove (not blank out) when previously unset, so the default applies
+            // again regardless of test order.
+            if (prev == null) {
+                JMeterUtils.getJMeterProperties().remove(key);
+            } else {
+                JMeterUtils.setProperty(key, prev);
+            }
         }
     }
 }

--- a/src/test/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapterTest.java
+++ b/src/test/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapterTest.java
@@ -1,0 +1,96 @@
+package org.qainsights.jmeter.ai.claudecode;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link KiroCliAdapter}.
+ * <p>
+ * The protected {@link BaseCliAdapter#findOnPath(String)} is overridden in
+ * anonymous subclasses so tests never invoke a real system process.
+ */
+class KiroCliAdapterTest {
+
+    // ── getName ────────────────────────────────────────────────────────────────
+
+    @Test
+    void getName_returnsAwsKiro() {
+        assertEquals("AWS Kiro", new KiroCliAdapter().getName());
+    }
+
+    @Test
+    void toString_returnsAwsKiro() {
+        assertEquals("AWS Kiro", new KiroCliAdapter().toString());
+    }
+
+    // ── getBinaryPath before detect ────────────────────────────────────────────
+
+    @Test
+    void getBinaryPath_returnsNullBeforeDetect() {
+        assertNull(new KiroCliAdapter().getBinaryPath());
+    }
+
+    // ── detect ─────────────────────────────────────────────────────────────────
+
+    @Test
+    void detect_whenKiroCliOnPath_returnsTrueAndSetsPath() {
+        KiroCliAdapter adapter = new KiroCliAdapter() {
+            @Override
+            protected String findOnPath(String binaryName) {
+                return "kiro-cli".equals(binaryName) ? "/home/me/.kiro/bin/kiro-cli" : null;
+            }
+        };
+        assertTrue(adapter.detect());
+        assertEquals("/home/me/.kiro/bin/kiro-cli", adapter.getBinaryPath());
+    }
+
+    @Test
+    void detect_prefersKiroCliOverShortKiroAlias() {
+        String[] firstQueried = {null};
+        KiroCliAdapter adapter = new KiroCliAdapter() {
+            @Override
+            protected String findOnPath(String binaryName) {
+                if (firstQueried[0] == null) {
+                    firstQueried[0] = binaryName;
+                }
+                return null;
+            }
+        };
+        adapter.detect();
+        assertEquals("kiro-cli", firstQueried[0]);
+    }
+
+    @Test
+    void detect_fallsBackToKiroAliasWhenKiroCliMissing() {
+        KiroCliAdapter adapter = new KiroCliAdapter() {
+            @Override
+            protected String findOnPath(String binaryName) {
+                return "kiro".equals(binaryName) ? "/usr/local/bin/kiro" : null;
+            }
+        };
+        assertTrue(adapter.detect());
+        assertEquals("/usr/local/bin/kiro", adapter.getBinaryPath());
+    }
+
+    // ── buildCommand ───────────────────────────────────────────────────────────
+
+    @Test
+    void buildCommand_afterDetect_appendsChatSubcommand() {
+        KiroCliAdapter adapter = new KiroCliAdapter() {
+            @Override
+            protected String findOnPath(String binaryName) {
+                return "/usr/local/bin/kiro-cli";
+            }
+        };
+        adapter.detect();
+
+        List<String> command = adapter.buildCommand(null);
+
+        assertEquals(2, command.size());
+        assertEquals("/usr/local/bin/kiro-cli", command.get(0));
+        assertEquals("chat", command.get(1));
+    }
+}

--- a/src/test/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapterTest.java
+++ b/src/test/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapterTest.java
@@ -1,7 +1,11 @@
 package org.qainsights.jmeter.ai.claudecode;
 
+import org.apache.jmeter.util.JMeterUtils;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -13,6 +17,16 @@ import static org.junit.jupiter.api.Assertions.*;
  * anonymous subclasses so tests never invoke a real system process.
  */
 class KiroCliAdapterTest {
+
+    @BeforeAll
+    static void initJMeterProperties() throws IOException {
+        // setProperty needs an initialized properties object; load an empty one.
+        if (JMeterUtils.getJMeterProperties() == null) {
+            File tmp = File.createTempFile("jmeter-test", ".properties");
+            tmp.deleteOnExit();
+            JMeterUtils.loadJMeterProperties(tmp.getAbsolutePath());
+        }
+    }
 
     // ── getName ────────────────────────────────────────────────────────────────
 
@@ -79,18 +93,62 @@ class KiroCliAdapterTest {
 
     @Test
     void buildCommand_afterDetect_appendsChatSubcommand() {
-        KiroCliAdapter adapter = new KiroCliAdapter() {
-            @Override
-            protected String findOnPath(String binaryName) {
-                return "/usr/local/bin/kiro-cli";
-            }
-        };
-        adapter.detect();
+        KiroCliAdapter adapter = detectedAdapter("/usr/local/bin/kiro-cli");
 
         List<String> command = adapter.buildCommand(null);
 
-        assertEquals(2, command.size());
         assertEquals("/usr/local/bin/kiro-cli", command.get(0));
         assertEquals("chat", command.get(1));
+    }
+
+    // ── tool-trust policy ──────────────────────────────────────────────────────
+
+    @Test
+    void buildCommand_byDefault_restrictsToReadOnlyTrustedTools() {
+        KiroCliAdapter adapter = detectedAdapter("/usr/local/bin/kiro-cli");
+
+        List<String> command = adapter.buildCommand(null);
+
+        assertTrue(command.contains("--trust-tools=read,grep,fs_read"),
+                "default policy must trust only read-only tools: " + command);
+        assertFalse(command.contains("--trust-all-tools"));
+    }
+
+    @Test
+    void buildCommand_whenTrustAllToolsEnabled_usesTrustAllFlag() {
+        withProperty("jmeter.ai.terminal.kiro.trust_all_tools", "true", () -> {
+            List<String> command = detectedAdapter("/usr/local/bin/kiro-cli").buildCommand(null);
+            assertTrue(command.contains("--trust-all-tools"), command.toString());
+            assertFalse(command.stream().anyMatch(s -> s.startsWith("--trust-tools=")));
+        });
+    }
+
+    @Test
+    void buildCommand_whenTrustToolsBlank_omitsTrustFlag() {
+        withProperty("jmeter.ai.terminal.kiro.trust_tools", "", () -> {
+            List<String> command = detectedAdapter("/usr/local/bin/kiro-cli").buildCommand(null);
+            assertFalse(command.stream().anyMatch(s -> s.startsWith("--trust-tools")), command.toString());
+        });
+    }
+
+    private static KiroCliAdapter detectedAdapter(String binary) {
+        KiroCliAdapter adapter = new KiroCliAdapter() {
+            @Override
+            protected String findOnPath(String binaryName) {
+                return binary;
+            }
+        };
+        adapter.detect();
+        return adapter;
+    }
+
+    private static void withProperty(String key, String value, Runnable body) {
+        String prev = org.apache.jmeter.util.JMeterUtils.getProperty(key);
+        try {
+            org.apache.jmeter.util.JMeterUtils.setProperty(key, value);
+            body.run();
+        } finally {
+            org.apache.jmeter.util.JMeterUtils.setProperty(key, prev == null ? "" : prev);
+        }
     }
 }

--- a/src/test/java/org/qainsights/jmeter/ai/security/AuditLoggerTest.java
+++ b/src/test/java/org/qainsights/jmeter/ai/security/AuditLoggerTest.java
@@ -1,0 +1,96 @@
+package org.qainsights.jmeter.ai.security;
+
+import org.apache.jmeter.util.JMeterUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link AuditLogger}. Exercises JSON encoding, the content hash,
+ * and end-to-end append behaviour against a temp audit file.
+ */
+class AuditLoggerTest {
+
+    @BeforeAll
+    static void initJMeterProperties() throws IOException {
+        if (JMeterUtils.getJMeterProperties() == null) {
+            File tmp = File.createTempFile("jmeter-test", ".properties");
+            tmp.deleteOnExit();
+            JMeterUtils.loadJMeterProperties(tmp.getAbsolutePath());
+        }
+    }
+
+    @Test
+    void escape_handlesQuotesNewlinesAndControlChars() {
+        assertEquals("a\\\"b", AuditLogger.escape("a\"b"));
+        assertEquals("line1\\nline2", AuditLogger.escape("line1\nline2"));
+        assertEquals("", AuditLogger.escape(null));
+    }
+
+    @Test
+    void sha256_isStableAndHex() {
+        String a = AuditLogger.sha256("hello");
+        String b = AuditLogger.sha256("hello");
+        assertEquals(a, b);
+        assertEquals(64, a.length());
+        assertTrue(a.matches("[0-9a-f]{64}"));
+        assertNotEquals(a, AuditLogger.sha256("world"));
+        assertEquals("", AuditLogger.sha256(null));
+    }
+
+    @Test
+    void recordLaunch_appendsOneJsonLineWithExpectedFields(@TempDir Path dir) throws IOException {
+        Path audit = dir.resolve("audit.log");
+        withProperty("jmeter.ai.security.audit.file", audit.toString(), () -> {
+            List<String> command = Arrays.asList("/usr/local/bin/kiro-cli", "chat",
+                    "--trust-tools=read,grep,fs_read");
+            AuditLogger.recordLaunch("AWS Kiro", "/usr/local/bin/kiro-cli", command,
+                    "/work/dir", "  | HTTPSampler.path = /api");
+        });
+
+        List<String> lines = Files.readAllLines(audit);
+        assertEquals(1, lines.size());
+        String line = lines.get(0);
+        assertTrue(line.startsWith("{") && line.endsWith("}"), line);
+        assertTrue(line.contains("\"event\":\"ai_cli_launch\""), line);
+        assertTrue(line.contains("\"cli\":\"AWS Kiro\""), line);
+        assertTrue(line.contains("--trust-tools=read,grep,fs_read"), line);
+        assertTrue(line.contains("\"contextSha256\":\""), line);
+        assertFalse(line.contains("\n\n"));
+    }
+
+    @Test
+    void recordLaunch_whenDisabled_writesNothing(@TempDir Path dir) throws IOException {
+        Path audit = dir.resolve("audit-disabled.log");
+        withProperty("jmeter.ai.security.audit.enabled", "false", () ->
+                withProperty("jmeter.ai.security.audit.file", audit.toString(), () ->
+                        AuditLogger.recordLaunch("AWS Kiro", "/bin/kiro-cli",
+                                Arrays.asList("/bin/kiro-cli", "chat"), "/work", "ctx")));
+        assertFalse(Files.exists(audit), "no audit file should be created when disabled");
+    }
+
+    private static void withProperty(String key, String value, Runnable body) {
+        String prev = JMeterUtils.getProperty(key);
+        try {
+            JMeterUtils.setProperty(key, value);
+            body.run();
+        } finally {
+            // Remove (not blank out) when the key was previously unset, so the
+            // configured default applies again regardless of test order.
+            if (prev == null) {
+                JMeterUtils.getJMeterProperties().remove(key);
+            } else {
+                JMeterUtils.setProperty(key, prev);
+            }
+        }
+    }
+}

--- a/src/test/java/org/qainsights/jmeter/ai/security/SecretRedactorTest.java
+++ b/src/test/java/org/qainsights/jmeter/ai/security/SecretRedactorTest.java
@@ -1,0 +1,67 @@
+package org.qainsights.jmeter.ai.security;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link SecretRedactor}. Redaction is on by default (no JMeter
+ * properties loaded), so these exercise the default-enabled behaviour.
+ */
+class SecretRedactorTest {
+
+    @Test
+    void masksPropertyStyleSecretButKeepsKey() {
+        String in = "  | HTTPSampler.password = s3cr3tV4lue\n  | HTTPSampler.path = /api/login";
+        String out = SecretRedactor.redact(in);
+
+        assertFalse(out.contains("s3cr3tV4lue"), out);
+        assertTrue(out.contains("HTTPSampler.password = " + SecretRedactor.MASK), out);
+        // Non-secret values are untouched.
+        assertTrue(out.contains("/api/login"), out);
+    }
+
+    @Test
+    void masksJsonStyleTokenField() {
+        String in = "{\"api_key\":\"AKIA1234567890\",\"region\":\"us-east-1\"}";
+        String out = SecretRedactor.redact(in);
+
+        assertFalse(out.contains("AKIA1234567890"), out);
+        assertTrue(out.contains("us-east-1"), out);
+    }
+
+    @Test
+    void masksBearerToken() {
+        String in = "Authorization: Bearer abc123DEF456ghi789";
+        String out = SecretRedactor.redact(in);
+
+        assertFalse(out.contains("abc123DEF456ghi789"), out);
+        assertTrue(out.contains(SecretRedactor.MASK), out);
+    }
+
+    @Test
+    void masksStandaloneJwt() {
+        String in = "cookie value eyJhbGciOiJIUzI1Ni19.eyJzdWIiOiIxMjM0NTY.SflKxwRJSMeKKF2QT4";
+        String out = SecretRedactor.redact(in);
+
+        assertFalse(out.contains("eyJhbGciOiJIUzI1Ni19"), out);
+        assertTrue(out.contains(SecretRedactor.MASK), out);
+    }
+
+    @Test
+    void leavesBenignTextUnchanged() {
+        String in = "[ThreadGroup] Login Flow\n  | num_threads = 100\n  | ramp_time = 30";
+        assertEquals(in, SecretRedactor.redact(in));
+    }
+
+    @Test
+    void handlesNullAndEmpty() {
+        assertNull(SecretRedactor.redact(null));
+        assertEquals("", SecretRedactor.redact(""));
+    }
+
+    @Test
+    void isEnabledByDefault() {
+        assertTrue(SecretRedactor.isEnabled());
+    }
+}


### PR DESCRIPTION
## Summary

Adds an append-only **audit trail** for AI CLI usage, so security and compliance teams can answer *"who sent what to which AI, and when"* — a common requirement before an AI tool is approved for enterprise rollout.

> Note: stacks on #61 (Kiro adapter) and #62 (redaction + tool-trust); this branch contains all three commits. Review the `feat(security): audit log…` commit in isolation, or merge #61 → #62 → this in order.

## What it records

`AuditLogger` writes **one JSON line per AI CLI launch** to an append-only log:

```json
{"timestamp":"2026-06-12T15:04:05Z","event":"ai_cli_launch","user":"jdoe","host":"WIN-PERF01","cli":"AWS Kiro","binary":"C:\\Users\\jdoe\\.kiro\\bin\\kiro-cli.exe","command":"... chat --trust-tools=read,grep,fs_read","workingDir":"C:\\tests","redactionEnabled":"true","contextSha256":"<64-hex>","contextBytes":"2048"}
```

- **Command flags only — no secret values.** The shared context is captured as a **SHA-256 hash**, not stored verbatim, so the log proves exactly what was sent without itself becoming sensitive.
- Hooked into `ClaudeCodePanel` at the launch site; **best-effort and never throws**, so auditing can't disrupt a session.
- Default destination `<JMETER_HOME>/logs/jmeter-ai-audit.log` (falls back to `~/.jmeter-ai-audit.log`).
- Config: `jmeter.ai.security.audit.enabled` (default `true`), `jmeter.ai.security.audit.file`.

## Testing

`mvn clean test` → **BUILD SUCCESS**. `AuditLoggerTest` covers JSON escaping (quotes/newlines/control chars), the stable 64-char hex SHA-256, the end-to-end append + expected field set, and the disabled no-op. Dependency-free (manual JSON encoding); Java 8 compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an append-only audit trail for external AI CLI launches so teams can see who ran what, when, and a SHA‑256 of the shared (redacted) context without storing the content itself. Also adds secret redaction by default and AWS Kiro CLI support with a safe, read‑only tool‑trust default.

- New Features
  - Audit log (`AuditLogger`): appends one JSON line per launch (timestamp, user, host, CLI, binary, command flags, working dir, redaction state, context SHA‑256, byte count). Default file `<JMETER_HOME>/logs/jmeter-ai-audit.log` (fallback `~/.jmeter-ai-audit.log`). Config: `jmeter.ai.security.audit.enabled` (default `true`), `jmeter.ai.security.audit.file`. Best‑effort; never throws.
  - Secret redaction (`SecretRedactor`): masks passwords, tokens, bearer/JWT before writing `CLAUDE.md`, `AGENTS.md`, and `KIRO.md` or sending to any CLI. Config: `jmeter.ai.security.redaction.enabled` (default `true`), `jmeter.ai.security.redaction.extra_keys`.
  - AWS Kiro CLI adapter (`KiroCliAdapter`): detects `kiro-cli` via override, PATH, or default install locations; launches `kiro-cli chat`. Mirrors context to `AGENTS.md`/`KIRO.md`.
  - Tool trust defaults: launches Kiro with `--trust-tools=read,grep,fs_read` by default. Override with `jmeter.ai.terminal.kiro.trust_all_tools=true` or customize `jmeter.ai.terminal.kiro.trust_tools`.

<sup>Written for commit d1f44ad32921510a057faa54d9727d8a06aa73be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/QAInsights/jmeter-ai/pull/63?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

