### PR TITLE
feat(mcp): wire MCP servers (JMeter MCP server) into AI CLIs

### DIFF
--- a/jmeter-ai-sample.properties
+++ b/jmeter-ai-sample.properties
@@ -44,6 +44,23 @@ Analyzing and optimizing JMeter test plans \
 - JMeter scripting and configuration \
 - Write, debug, and test Java code \
 - Write, debug, and test Groovy script
+# AWS Kiro CLI (kiro-cli) - enabled by default
+jmeter.ai.terminal.kiro.enabled=true
+# Optional: full path to the kiro-cli binary. Leave blank to auto-detect on PATH
+# and in Kiro's default install location.
+# Windows example: C:\Users\YOUR_USER_NAME\.kiro\bin\kiro-cli.exe
+# Linux/macOS example: /home/YOUR_USER_NAME/.kiro/bin/kiro-cli
+jmeter.ai.terminal.kiro.path=
+jmeter.ai.terminal.kiro.prompt=You are an AI assistant integrated into Apache JMeter via the FeatherWand plugin. \
+You have access to the current JMeter test plan structure. \
+Help the user with performance testing tasks including: \
+Analyzing and optimizing JMeter test plans \
+- Creating new test elements (Thread Groups, Samplers, Assertions, etc.) \
+- Debugging test plan issues \
+- Performance testing best practices \
+- JMeter scripting and configuration \
+- Write, debug, and test Java code \
+- Write, debug, and test Groovy script
 # Antigravity CLI (Google) - disabled by default
 jmeter.ai.terminal.antigravity.enabled=false
 jmeter.ai.terminal.antigravity.prompt=You are an AI assistant integrated into Apache JMeter via the FeatherWand plugin. \

--- a/jmeter-ai-sample.properties
+++ b/jmeter-ai-sample.properties
@@ -35,6 +35,13 @@ jmeter.ai.security.redaction.enabled=true
 # Optional extra key fragments to redact, comma-separated (e.g. pin,otp,ssn)
 jmeter.ai.security.redaction.extra_keys=
 
+# Audit log: append one JSON line per AI CLI launch (user, host, CLI, command
+# flags, working dir, redaction state, and a SHA-256 of the shared context).
+# The content itself is never logged - only its hash - so the trail is safe to
+# retain. Default file: <JMETER_HOME>/logs/jmeter-ai-audit.log
+jmeter.ai.security.audit.enabled=true
+jmeter.ai.security.audit.file=
+
 ##### AI Terminal Settings #####
 jmeter.ai.terminal.claudecode.enabled=true
 # Full path containing the claude executable

--- a/jmeter-ai-sample.properties
+++ b/jmeter-ai-sample.properties
@@ -27,6 +27,14 @@ jmeter.ai.correlation.min_value_length=3
 # Higher values require more randomness. Set to 0 to disable entropy-based detection.
 jmeter.ai.correlation.min_entropy=2.8
 
+##### AI Security / Governance #####
+# Redact secrets (passwords, tokens, API keys, bearer/JWT) from the test-plan
+# context before it is written to CLAUDE.md / AGENTS.md / KIRO.md and sent to any
+# AI CLI. Strongly recommended; set to false only in trusted, offline setups.
+jmeter.ai.security.redaction.enabled=true
+# Optional extra key fragments to redact, comma-separated (e.g. pin,otp,ssn)
+jmeter.ai.security.redaction.extra_keys=
+
 ##### AI Terminal Settings #####
 jmeter.ai.terminal.claudecode.enabled=true
 # Full path containing the claude executable
@@ -51,6 +59,11 @@ jmeter.ai.terminal.kiro.enabled=true
 # Windows example: C:\Users\YOUR_USER_NAME\.kiro\bin\kiro-cli.exe
 # Linux/macOS example: /home/YOUR_USER_NAME/.kiro/bin/kiro-cli
 jmeter.ai.terminal.kiro.path=
+# Tool-trust policy. Defaults to read-only tools so the agent cannot mutate the
+# test plan or filesystem without an explicit opt-in. Admins can lock this in a
+# managed user.properties. Set trust_all_tools=true only for trusted operators.
+jmeter.ai.terminal.kiro.trust_tools=read,grep,fs_read
+jmeter.ai.terminal.kiro.trust_all_tools=false
 jmeter.ai.terminal.kiro.prompt=You are an AI assistant integrated into Apache JMeter via the FeatherWand plugin. \
 You have access to the current JMeter test plan structure. \
 Help the user with performance testing tasks including: \

--- a/jmeter-ai-sample.properties
+++ b/jmeter-ai-sample.properties
@@ -42,6 +42,14 @@ jmeter.ai.security.redaction.extra_keys=
 jmeter.ai.security.audit.enabled=true
 jmeter.ai.security.audit.file=
 
+# Headless / CI mode (no GUI): run a single AI prompt against a test plan from a
+# pipeline and emit a report artifact. Redaction, tool-trust, and audit settings
+# above all apply. Kiro headless needs KIRO_API_KEY in the environment.
+#   java -cp lib/ext/jmeter-agent.jar \
+#        org.qainsights.jmeter.ai.headless.HeadlessAiRunner \
+#        --jmx test.jmx --prompt "Lint this plan and flag risky elements" \
+#        --output report.md --fail-on-error
+
 ##### AI Terminal Settings #####
 jmeter.ai.terminal.claudecode.enabled=true
 # Full path containing the claude executable

--- a/jmeter-ai-sample.properties
+++ b/jmeter-ai-sample.properties
@@ -50,6 +50,20 @@ jmeter.ai.security.audit.file=
 #        --jmx test.jmx --prompt "Lint this plan and flag risky elements" \
 #        --output report.md --fail-on-error
 
+##### AI MCP (Model Context Protocol) #####
+# Wire MCP servers into the working directory so the agent can run JMeter tests
+# and parse JTL results through tools instead of free text. For Kiro this writes
+# <test-plan-dir>/.kiro/settings/mcp.json. Only written when a server is
+# configured below, so the default is a no-op.
+jmeter.ai.mcp.enabled=true
+# Path to a local checkout of https://github.com/QAInsights/jmeter-mcp-server
+# Leave blank to disable. The server is launched as:
+#   <command> --directory <dir> run jmeter_server.py
+jmeter.ai.mcp.jmeter.dir=
+jmeter.ai.mcp.jmeter.command=uv
+# Optional: comma-separated MCP tools to auto-approve (no per-call prompt)
+jmeter.ai.mcp.jmeter.autoApprove=
+
 ##### AI Terminal Settings #####
 jmeter.ai.terminal.claudecode.enabled=true
 # Full path containing the claude executable

--- a/run-ai-headless.bat
+++ b/run-ai-headless.bat
@@ -1,0 +1,24 @@
+@echo off
+REM Run the JMeter AI headless runner from a CI pipeline (Windows).
+REM
+REM Usage:
+REM   run-ai-headless.bat --jmx test.jmx --prompt "Lint this plan" --fail-on-error
+REM
+REM Requires KIRO_API_KEY in the environment for Kiro headless runs.
+setlocal
+
+set "SCRIPT_DIR=%~dp0"
+set "JAR="
+
+for %%F in ("%SCRIPT_DIR%target\jmeter-agent-*.jar") do set "JAR=%%F"
+if not defined JAR if defined JMETER_HOME for %%F in ("%JMETER_HOME%\lib\ext\jmeter-agent*.jar") do set "JAR=%%F"
+
+if not defined JAR (
+  echo Could not find jmeter-agent jar. Build with "mvn package" or set JMETER_HOME. 1>&2
+  exit /b 3
+)
+
+set "CP=%JAR%"
+if defined JMETER_HOME if exist "%JMETER_HOME%\lib" set "CP=%JAR%;%JMETER_HOME%\lib\*;%JMETER_HOME%\lib\ext\*"
+
+java -cp "%CP%" org.qainsights.jmeter.ai.headless.HeadlessAiRunner %*

--- a/run-ai-headless.sh
+++ b/run-ai-headless.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Run the JMeter AI headless runner from a CI pipeline.
+#
+# Usage:
+#   ./run-ai-headless.sh --jmx test.jmx --prompt "Lint this plan" --fail-on-error
+#
+# Requires KIRO_API_KEY in the environment for Kiro headless runs.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Locate the plugin jar: prefer a built target/ artifact, else JMeter's lib/ext.
+JAR=""
+for candidate in \
+    "$SCRIPT_DIR"/target/jmeter-agent-*.jar \
+    "${JMETER_HOME:-}"/lib/ext/jmeter-agent*.jar \
+    "$SCRIPT_DIR"/lib/ext/jmeter-agent*.jar; do
+  if [ -f "$candidate" ]; then JAR="$candidate"; break; fi
+done
+
+if [ -z "$JAR" ]; then
+  echo "Could not find jmeter-agent jar. Build with 'mvn package' or set JMETER_HOME." >&2
+  exit 3
+fi
+
+# Include JMeter's libs on the classpath if available (for JMeterUtils etc.).
+CP="$JAR"
+if [ -n "${JMETER_HOME:-}" ] && [ -d "$JMETER_HOME/lib" ]; then
+  CP="$JAR:$JMETER_HOME/lib/*:$JMETER_HOME/lib/ext/*"
+fi
+
+exec java -cp "$CP" org.qainsights.jmeter.ai.headless.HeadlessAiRunner "$@"

--- a/src/main/java/org/qainsights/jmeter/ai/claudecode/BaseCliAdapter.java
+++ b/src/main/java/org/qainsights/jmeter/ai/claudecode/BaseCliAdapter.java
@@ -106,4 +106,22 @@ public abstract class BaseCliAdapter implements AiCliAdapter {
         throw new UnsupportedOperationException(getName() + " does not support headless mode");
     }
 
+    /**
+     * @return {@code true} if this CLI reads a project-scoped MCP config file.
+     *         Defaults to {@code false}; CLIs that do override this together with
+     *         {@link #mcpConfigRelativePath()}.
+     */
+    public boolean supportsMcp() {
+        return false;
+    }
+
+    /**
+     * @return the MCP config path this CLI reads, <em>relative to the working
+     *         directory</em> (e.g. {@code .kiro/settings/mcp.json}), or
+     *         {@code null} if MCP wiring is not supported.
+     */
+    public String mcpConfigRelativePath() {
+        return null;
+    }
+
 }

--- a/src/main/java/org/qainsights/jmeter/ai/claudecode/BaseCliAdapter.java
+++ b/src/main/java/org/qainsights/jmeter/ai/claudecode/BaseCliAdapter.java
@@ -84,4 +84,26 @@ public abstract class BaseCliAdapter implements AiCliAdapter {
                 "Help the user to optimize the JMeter test plan, scripting, and performance related issues.";
     }
 
+    /**
+     * @return {@code true} if this CLI can run a single prompt non-interactively
+     *         (for CI/headless use). Defaults to {@code false}; CLIs that support
+     *         it override this together with {@link #buildHeadlessCommand}.
+     */
+    public boolean supportsHeadless() {
+        return false;
+    }
+
+    /**
+     * Build the command for a one-shot, non-interactive run of {@code prompt}.
+     * Only meaningful when {@link #supportsHeadless()} is {@code true}.
+     *
+     * @param prompt           the natural-language request
+     * @param workingDirectory directory the CLI runs in (holds the context files)
+     * @return full argv starting with the binary path
+     * @throws UnsupportedOperationException if this CLI has no headless mode
+     */
+    public List<String> buildHeadlessCommand(String prompt, String workingDirectory) {
+        throw new UnsupportedOperationException(getName() + " does not support headless mode");
+    }
+
 }

--- a/src/main/java/org/qainsights/jmeter/ai/claudecode/ClaudeCodePanel.java
+++ b/src/main/java/org/qainsights/jmeter/ai/claudecode/ClaudeCodePanel.java
@@ -289,6 +289,15 @@ public class ClaudeCodePanel extends JPanel {
                                 ? selectedCli.buildCommand(testPlanDir)
                                 : new ArrayList<>(Arrays.asList(claudeBinary));
 
+                        // Audit trail: record who launched which CLI, with what flags,
+                        // and a hash of the (redacted) context that was shared.
+                        org.qainsights.jmeter.ai.security.AuditLogger.recordLaunch(
+                                selectedCli != null ? selectedCli.getName() : "unknown",
+                                claudeBinary,
+                                command,
+                                testPlanDir,
+                                org.qainsights.jmeter.ai.security.SecretRedactor.redact(systemPrompt));
+
                         // Set up environment
                         Map<String, String> env = new HashMap<>(System.getenv());
                         env.put("TERM", "xterm-256color");

--- a/src/main/java/org/qainsights/jmeter/ai/claudecode/ClaudeCodePanel.java
+++ b/src/main/java/org/qainsights/jmeter/ai/claudecode/ClaudeCodePanel.java
@@ -262,17 +262,22 @@ public class ClaudeCodePanel extends JPanel {
                         // by PtyProcessBuilder, causing stray text to be sent as user input)
                         if (testPlanDir != null) {
                             try {
+                                // Redact secrets (passwords, tokens, API keys) before any
+                                // context leaves JMeter for an external AI CLI. Enabled by
+                                // default; see jmeter.ai.security.redaction.enabled.
+                                byte[] contextBytes = org.qainsights.jmeter.ai.security.SecretRedactor
+                                        .redact(systemPrompt).getBytes(StandardCharsets.UTF_8);
+
                                 claudeMdFile = new File(testPlanDir, "CLAUDE.md");
-                                Files.write(claudeMdFile.toPath(),
-                                        systemPrompt.getBytes(StandardCharsets.UTF_8));
-                                log.info("Wrote CLAUDE.md to: {}", claudeMdFile.getAbsolutePath());
+                                Files.write(claudeMdFile.toPath(), contextBytes);
+                                log.info("Wrote CLAUDE.md to: {} (redaction enabled={})",
+                                        claudeMdFile.getAbsolutePath(),
+                                        org.qainsights.jmeter.ai.security.SecretRedactor.isEnabled());
 
                                 // AWS Kiro (and other agents) read AGENTS.md / KIRO.md
                                 // instead of CLAUDE.md, so mirror the same context there.
-                                Files.write(new File(testPlanDir, "AGENTS.md").toPath(),
-                                        systemPrompt.getBytes(StandardCharsets.UTF_8));
-                                Files.write(new File(testPlanDir, "KIRO.md").toPath(),
-                                        systemPrompt.getBytes(StandardCharsets.UTF_8));
+                                Files.write(new File(testPlanDir, "AGENTS.md").toPath(), contextBytes);
+                                Files.write(new File(testPlanDir, "KIRO.md").toPath(), contextBytes);
                             } catch (Exception e) {
                                 log.warn("Could not write CLAUDE.md", e);
                                 claudeMdFile = null;

--- a/src/main/java/org/qainsights/jmeter/ai/claudecode/ClaudeCodePanel.java
+++ b/src/main/java/org/qainsights/jmeter/ai/claudecode/ClaudeCodePanel.java
@@ -116,6 +116,10 @@ public class ClaudeCodePanel extends JPanel {
         if (antigravity.isEnabled() && antigravity.detect())
             available.add(antigravity);
 
+        AiCliAdapter kiro = new KiroCliAdapter();
+        if (kiro.isEnabled() && kiro.detect())
+            available.add(kiro);
+
         return available;
     }
 
@@ -262,6 +266,13 @@ public class ClaudeCodePanel extends JPanel {
                                 Files.write(claudeMdFile.toPath(),
                                         systemPrompt.getBytes(StandardCharsets.UTF_8));
                                 log.info("Wrote CLAUDE.md to: {}", claudeMdFile.getAbsolutePath());
+
+                                // AWS Kiro (and other agents) read AGENTS.md / KIRO.md
+                                // instead of CLAUDE.md, so mirror the same context there.
+                                Files.write(new File(testPlanDir, "AGENTS.md").toPath(),
+                                        systemPrompt.getBytes(StandardCharsets.UTF_8));
+                                Files.write(new File(testPlanDir, "KIRO.md").toPath(),
+                                        systemPrompt.getBytes(StandardCharsets.UTF_8));
                             } catch (Exception e) {
                                 log.warn("Could not write CLAUDE.md", e);
                                 claudeMdFile = null;

--- a/src/main/java/org/qainsights/jmeter/ai/claudecode/ClaudeCodePanel.java
+++ b/src/main/java/org/qainsights/jmeter/ai/claudecode/ClaudeCodePanel.java
@@ -284,6 +284,14 @@ public class ClaudeCodePanel extends JPanel {
                             }
                         }
 
+                        // Wire MCP servers (e.g. the JMeter MCP server) into the
+                        // working directory so the agent can run tests and parse JTLs
+                        // through tools rather than free text.
+                        if (selectedCli instanceof BaseCliAdapter && testPlanDir != null) {
+                            org.qainsights.jmeter.ai.mcp.McpConfigWriter.writeFor(
+                                    (BaseCliAdapter) selectedCli, new File(testPlanDir));
+                        }
+
                         // Build command with arguments (each adapter provides its own flags)
                         List<String> command = selectedCli != null
                                 ? selectedCli.buildCommand(testPlanDir)

--- a/src/main/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapter.java
+++ b/src/main/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapter.java
@@ -97,6 +97,20 @@ public class KiroCliAdapter extends BaseCliAdapter {
         // from the working directory for test-plan context.
         List<String> command = super.buildCommand(workingDirectory);
         command.add("chat");
+
+        // Governed tool-trust policy. Defaults to read-only tools so the agent
+        // cannot mutate the test plan or filesystem without an explicit opt-in.
+        // Admins can lock either property via a managed user.properties.
+        if (AiConfig.getProperty("jmeter.ai.terminal.kiro.trust_all_tools", "false")
+                .equalsIgnoreCase("true")) {
+            command.add("--trust-all-tools");
+        } else {
+            String trustTools = AiConfig
+                    .getProperty("jmeter.ai.terminal.kiro.trust_tools", "read,grep,fs_read").trim();
+            if (!trustTools.isEmpty()) {
+                command.add("--trust-tools=" + trustTools);
+            }
+        }
         return command;
     }
 

--- a/src/main/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapter.java
+++ b/src/main/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapter.java
@@ -97,10 +97,33 @@ public class KiroCliAdapter extends BaseCliAdapter {
         // from the working directory for test-plan context.
         List<String> command = super.buildCommand(workingDirectory);
         command.add("chat");
+        appendTrustFlags(command);
+        return command;
+    }
 
-        // Governed tool-trust policy. Defaults to read-only tools so the agent
-        // cannot mutate the test plan or filesystem without an explicit opt-in.
-        // Admins can lock either property via a managed user.properties.
+    @Override
+    public boolean supportsHeadless() {
+        return true;
+    }
+
+    @Override
+    public List<String> buildHeadlessCommand(String prompt, String workingDirectory) {
+        // Kiro CLI 2.0 headless: kiro-cli chat --no-interactive [trust] "<prompt>"
+        // Requires KIRO_API_KEY in the environment (Pro tier+).
+        List<String> command = super.buildCommand(workingDirectory);
+        command.add("chat");
+        command.add("--no-interactive");
+        appendTrustFlags(command);
+        command.add(prompt == null ? "" : prompt);
+        return command;
+    }
+
+    /**
+     * Append the governed tool-trust policy. Defaults to read-only tools so the
+     * agent cannot mutate the test plan or filesystem without an explicit opt-in.
+     * Admins can lock either property via a managed user.properties.
+     */
+    private void appendTrustFlags(List<String> command) {
         if (AiConfig.getProperty("jmeter.ai.terminal.kiro.trust_all_tools", "false")
                 .equalsIgnoreCase("true")) {
             command.add("--trust-all-tools");
@@ -111,7 +134,6 @@ public class KiroCliAdapter extends BaseCliAdapter {
                 command.add("--trust-tools=" + trustTools);
             }
         }
-        return command;
     }
 
     @Override

--- a/src/main/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapter.java
+++ b/src/main/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapter.java
@@ -1,0 +1,117 @@
+package org.qainsights.jmeter.ai.claudecode;
+
+import org.qainsights.jmeter.ai.utils.AiConfig;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Adapter for the <strong>AWS Kiro</strong> agentic CLI ({@code kiro-cli}).
+ *
+ * <p>Kiro is not found by a plain {@code PATH} scan in two common situations on
+ * Windows: its binary is {@code kiro-cli.exe} (not {@code claude}/{@code codex}/…),
+ * and its installer adds {@code %USERPROFILE%\.kiro\bin} to the user PATH only for
+ * <em>newly</em> launched processes — an already-running JMeter never sees it.
+ * This adapter therefore resolves the binary in three steps:
+ *
+ * <ol>
+ *   <li>an explicit {@code jmeter.ai.terminal.kiro.path} override;</li>
+ *   <li>the system {@code PATH} ({@code kiro-cli}, then {@code kiro});</li>
+ *   <li>Kiro's well-known default install locations.</li>
+ * </ol>
+ *
+ * <p>The terminal launches Kiro interactively with {@code kiro-cli chat}; the test
+ * plan context is supplied via the {@code AGENTS.md}/{@code KIRO.md} files that
+ * {@code ClaudeCodePanel} writes into the working directory.
+ */
+public class KiroCliAdapter extends BaseCliAdapter {
+
+    @Override
+    public String getName() {
+        return "AWS Kiro";
+    }
+
+    @Override
+    public boolean detect() {
+        // 1) Explicit override wins.
+        String override = AiConfig.getProperty("jmeter.ai.terminal.kiro.path", "");
+        if (override != null && !override.trim().isEmpty()) {
+            File f = new File(expandHome(override.trim()));
+            if (f.isFile()) {
+                detectedPath = f.getAbsolutePath();
+                return true;
+            }
+        }
+
+        // 2) System PATH (handles kiro-cli and the shorter kiro alias).
+        String onPath = findOnPath("kiro-cli");
+        if (onPath == null) {
+            onPath = findOnPath("kiro");
+        }
+        if (onPath != null) {
+            detectedPath = onPath;
+            return true;
+        }
+
+        // 3) Kiro's default install locations (covers the stale-PATH case).
+        for (File candidate : defaultInstallCandidates()) {
+            if (candidate.isFile()) {
+                detectedPath = candidate.getAbsolutePath();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private List<File> defaultInstallCandidates() {
+        List<File> out = new ArrayList<>();
+        String home = System.getProperty("user.home", "");
+        boolean isWindows = System.getProperty("os.name", "").toLowerCase().contains("win");
+        if (isWindows) {
+            out.add(Paths.get(home, ".kiro", "bin", "kiro-cli.exe").toFile());
+            String localAppData = System.getenv("LOCALAPPDATA");
+            if (localAppData != null && !localAppData.trim().isEmpty()) {
+                out.add(Paths.get(localAppData, "Programs", "kiro", "bin", "kiro-cli.exe").toFile());
+                out.add(Paths.get(localAppData, "kiro", "bin", "kiro-cli.exe").toFile());
+            }
+        } else {
+            out.add(Paths.get(home, ".kiro", "bin", "kiro-cli").toFile());
+            out.add(new File("/usr/local/bin/kiro-cli"));
+            out.add(new File("/opt/kiro/bin/kiro-cli"));
+        }
+        return out;
+    }
+
+    private static String expandHome(String path) {
+        if (path.equals("~") || path.startsWith("~/") || path.startsWith("~\\")) {
+            return System.getProperty("user.home", "") + path.substring(1);
+        }
+        return path;
+    }
+
+    @Override
+    public List<String> buildCommand(String workingDirectory) {
+        // Launch Kiro's interactive terminal UI. Kiro reads AGENTS.md / KIRO.md
+        // from the working directory for test-plan context.
+        List<String> command = super.buildCommand(workingDirectory);
+        command.add("chat");
+        return command;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return AiConfig.getProperty("jmeter.ai.terminal.kiro.enabled", "true").equals("true");
+    }
+
+    @Override
+    public String defaultPrompt() {
+        return AiConfig.getProperty("jmeter.ai.terminal.kiro.prompt",
+                "You are an AI assistant integrated into Apache JMeter via the FeatherWand plugin. " +
+                        "You have access to the current JMeter test plan structure. " +
+                        "Help the user with performance testing tasks: analyzing and optimizing JMeter " +
+                        "test plans, creating test elements, debugging issues, performance best practices, " +
+                        "and writing/debugging Groovy and Java (JSR223) code.");
+    }
+}

--- a/src/main/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapter.java
+++ b/src/main/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapter.java
@@ -107,6 +107,17 @@ public class KiroCliAdapter extends BaseCliAdapter {
     }
 
     @Override
+    public boolean supportsMcp() {
+        return true;
+    }
+
+    @Override
+    public String mcpConfigRelativePath() {
+        // Kiro reads workspace MCP config from <project-root>/.kiro/settings/mcp.json
+        return ".kiro/settings/mcp.json";
+    }
+
+    @Override
     public List<String> buildHeadlessCommand(String prompt, String workingDirectory) {
         // Kiro CLI 2.0 headless: kiro-cli chat --no-interactive [trust] "<prompt>"
         // Requires KIRO_API_KEY in the environment (Pro tier+).

--- a/src/main/java/org/qainsights/jmeter/ai/headless/DefaultProcessRunner.java
+++ b/src/main/java/org/qainsights/jmeter/ai/headless/DefaultProcessRunner.java
@@ -1,0 +1,46 @@
+package org.qainsights.jmeter.ai.headless;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Real {@link ProcessRunner} backed by {@link ProcessBuilder}. Streams combined
+ * stdout/stderr and enforces a wall-clock timeout.
+ */
+public class DefaultProcessRunner implements ProcessRunner {
+
+    @Override
+    public Result run(List<String> command, File workingDir, long timeoutSeconds,
+                      Map<String, String> env) throws Exception {
+        ProcessBuilder pb = new ProcessBuilder(command);
+        if (workingDir != null) {
+            pb.directory(workingDir);
+        }
+        pb.redirectErrorStream(true);
+        if (env != null) {
+            pb.environment().putAll(env);
+        }
+
+        Process process = pb.start();
+        StringBuilder output = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                output.append(line).append(System.lineSeparator());
+            }
+        }
+
+        boolean finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS);
+        if (!finished) {
+            process.destroyForcibly();
+            return new Result(124, output.toString(), true);
+        }
+        return new Result(process.exitValue(), output.toString(), false);
+    }
+}

--- a/src/main/java/org/qainsights/jmeter/ai/headless/HeadlessAiRunner.java
+++ b/src/main/java/org/qainsights/jmeter/ai/headless/HeadlessAiRunner.java
@@ -94,6 +94,10 @@ public final class HeadlessAiRunner {
         File workingDir = resolveWorkingDir(options);
         String sharedContext = prepareContext(options, workingDir);
 
+        // Wire MCP servers (e.g. the JMeter MCP server) so the agent can run tests
+        // and parse JTLs through tools rather than free text.
+        org.qainsights.jmeter.ai.mcp.McpConfigWriter.writeFor(cli, workingDir);
+
         List<String> command = cli.buildHeadlessCommand(prompt, workingDir.getAbsolutePath());
 
         AuditLogger.recordLaunch(cli.getName(), cli.getBinaryPath(), command,

--- a/src/main/java/org/qainsights/jmeter/ai/headless/HeadlessAiRunner.java
+++ b/src/main/java/org/qainsights/jmeter/ai/headless/HeadlessAiRunner.java
@@ -1,0 +1,208 @@
+package org.qainsights.jmeter.ai.headless;
+
+import org.apache.jmeter.util.JMeterUtils;
+import org.qainsights.jmeter.ai.claudecode.BaseCliAdapter;
+import org.qainsights.jmeter.ai.claudecode.KiroCliAdapter;
+import org.qainsights.jmeter.ai.security.AuditLogger;
+import org.qainsights.jmeter.ai.security.SecretRedactor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+/**
+ * Runs a single AI CLI prompt without the JMeter GUI, for use in CI pipelines
+ * and {@code jmeter -n} automation. Generates, optimizes, lints, or analyses a
+ * test plan (or its results) from natural language and writes a structured
+ * report artifact the build can archive and a PR can review.
+ *
+ * <p>Reuses the same governance as the GUI terminal: context is redacted via
+ * {@link SecretRedactor} before it is shared, the launch is recorded by
+ * {@link AuditLogger}, and the CLI's tool-trust policy applies.
+ *
+ * <p>Example:
+ * <pre>
+ *   java -cp jmeter-agent.jar org.qainsights.jmeter.ai.headless.HeadlessAiRunner \
+ *     --jmx test.jmx --prompt "Lint this plan and list risky elements" \
+ *     --output report.md --fail-on-error
+ * </pre>
+ */
+public final class HeadlessAiRunner {
+
+    private static final Logger log = LoggerFactory.getLogger(HeadlessAiRunner.class);
+
+    public static final int EXIT_OK = 0;
+    public static final int EXIT_USAGE = 2;
+    public static final int EXIT_CLI_NOT_FOUND = 3;
+    public static final int EXIT_HEADLESS_UNSUPPORTED = 4;
+    public static final int EXIT_TIMEOUT = 124;
+
+    public static void main(String[] args) {
+        int code;
+        try {
+            HeadlessOptions options = HeadlessOptions.parse(args);
+            if (options.help) {
+                System.out.println(HeadlessOptions.usage());
+                System.exit(EXIT_OK);
+            }
+            ensureJMeterProperties();
+            code = new HeadlessAiRunner().run(options, new DefaultProcessRunner(), null);
+        } catch (HeadlessUsageException e) {
+            System.err.println("Error: " + e.getMessage());
+            System.err.println();
+            System.err.println(HeadlessOptions.usage());
+            code = EXIT_USAGE;
+        } catch (Exception e) {
+            System.err.println("Headless run failed: " + e.getMessage());
+            code = 1;
+        }
+        System.exit(code);
+    }
+
+    /**
+     * Execute the run. Returns the process exit code to propagate. Does not call
+     * {@link System#exit}, so it is unit-testable with a fake {@link ProcessRunner}
+     * and adapter.
+     *
+     * @param adapter the CLI adapter to use, or {@code null} to resolve from
+     *                {@code options.cli}
+     */
+    public int run(HeadlessOptions options, ProcessRunner runner, BaseCliAdapter adapter)
+            throws Exception {
+
+        String prompt = resolvePrompt(options);
+        if (prompt == null || prompt.trim().isEmpty()) {
+            throw new HeadlessUsageException("A prompt is required (--prompt or --prompt-file)");
+        }
+
+        BaseCliAdapter cli = adapter != null ? adapter : resolveAdapter(options.cli);
+        if (!cli.detect()) {
+            System.err.println(cli.getName() + " was not found. Install it or set its path property.");
+            return EXIT_CLI_NOT_FOUND;
+        }
+        if (!cli.supportsHeadless()) {
+            System.err.println(cli.getName() + " does not support headless mode.");
+            return EXIT_HEADLESS_UNSUPPORTED;
+        }
+
+        File workingDir = resolveWorkingDir(options);
+        String sharedContext = prepareContext(options, workingDir);
+
+        List<String> command = cli.buildHeadlessCommand(prompt, workingDir.getAbsolutePath());
+
+        AuditLogger.recordLaunch(cli.getName(), cli.getBinaryPath(), command,
+                workingDir.getAbsolutePath(), sharedContext);
+
+        log.info("Running {} headless ({}s timeout): {}", cli.getName(), options.timeoutSeconds, command);
+        ProcessRunner.Result result = runner.run(command, workingDir, options.timeoutSeconds, null);
+
+        HeadlessReport report = new HeadlessReport(cli.getName(), cli.getBinaryPath(), prompt,
+                options.jmx, command, result.exitCode, result.timedOut, result.output);
+        writeReport(options, report);
+
+        System.out.println("AI headless run " + report.status() + " — report: " + options.output);
+
+        if (result.timedOut) {
+            return options.failOnError ? EXIT_TIMEOUT : EXIT_OK;
+        }
+        if (result.exitCode != 0) {
+            return options.failOnError ? result.exitCode : EXIT_OK;
+        }
+        return EXIT_OK;
+    }
+
+    private BaseCliAdapter resolveAdapter(String name) {
+        String n = name == null ? "" : name.trim().toLowerCase();
+        switch (n) {
+            case "":
+            case "kiro":
+            case "kiro-cli":
+            case "aws kiro":
+                return new KiroCliAdapter();
+            default:
+                throw new HeadlessUsageException(
+                        "Unknown or non-headless CLI: '" + name + "'. Supported: kiro");
+        }
+    }
+
+    private String resolvePrompt(HeadlessOptions options) throws IOException {
+        if (options.prompt != null && !options.prompt.isEmpty()) {
+            return options.prompt;
+        }
+        if (options.promptFile != null && !options.promptFile.isEmpty()) {
+            return new String(Files.readAllBytes(Paths.get(options.promptFile)), StandardCharsets.UTF_8);
+        }
+        return null;
+    }
+
+    private File resolveWorkingDir(HeadlessOptions options) throws IOException {
+        if (options.workingDir != null && !options.workingDir.isEmpty()) {
+            File dir = new File(options.workingDir);
+            Files.createDirectories(dir.toPath());
+            return dir;
+        }
+        return Files.createTempDirectory("jmeter-ai-headless-").toFile();
+    }
+
+    /**
+     * If a {@code .jmx} was supplied, read it, redact secrets, and write the
+     * context files Kiro reads ({@code KIRO.md} / {@code AGENTS.md} / {@code CLAUDE.md}).
+     *
+     * @return the redacted context that was shared (for the audit hash), or "".
+     */
+    private String prepareContext(HeadlessOptions options, File workingDir) throws IOException {
+        if (options.jmx == null || options.jmx.isEmpty()) {
+            return "";
+        }
+        Path jmxPath = Paths.get(options.jmx);
+        if (!Files.isRegularFile(jmxPath)) {
+            log.warn("--jmx not found, continuing without test-plan context: {}", options.jmx);
+            return "";
+        }
+        String raw = new String(Files.readAllBytes(jmxPath), StandardCharsets.UTF_8);
+        String context = "# JMeter Test Plan Context\n\n"
+                + "Source: " + jmxPath.toAbsolutePath() + "\n\n"
+                + "```xml\n" + raw + "\n```\n";
+        String redacted = SecretRedactor.redact(context);
+        byte[] bytes = redacted.getBytes(StandardCharsets.UTF_8);
+        Files.write(new File(workingDir, "KIRO.md").toPath(), bytes);
+        Files.write(new File(workingDir, "AGENTS.md").toPath(), bytes);
+        Files.write(new File(workingDir, "CLAUDE.md").toPath(), bytes);
+        return redacted;
+    }
+
+    private void writeReport(HeadlessOptions options, HeadlessReport report) throws IOException {
+        Path out = Paths.get(options.output);
+        if (out.getParent() != null) {
+            Files.createDirectories(out.getParent());
+        }
+        Files.write(out, report.render(options.format).getBytes(StandardCharsets.UTF_8));
+    }
+
+    /** Make AiConfig usable outside JMeter by ensuring a properties object exists. */
+    private static void ensureJMeterProperties() {
+        if (JMeterUtils.getJMeterProperties() != null) {
+            return;
+        }
+        try {
+            String home = System.getProperty("jmeter.home",
+                    System.getenv().getOrDefault("JMETER_HOME", ""));
+            File props = home.isEmpty() ? null : new File(home, "bin/jmeter.properties");
+            if (props != null && props.isFile()) {
+                JMeterUtils.loadJMeterProperties(props.getAbsolutePath());
+            } else {
+                File tmp = File.createTempFile("jmeter-ai", ".properties");
+                tmp.deleteOnExit();
+                JMeterUtils.loadJMeterProperties(tmp.getAbsolutePath());
+            }
+        } catch (IOException e) {
+            log.warn("Could not initialise JMeter properties: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/org/qainsights/jmeter/ai/headless/HeadlessOptions.java
+++ b/src/main/java/org/qainsights/jmeter/ai/headless/HeadlessOptions.java
@@ -1,0 +1,114 @@
+package org.qainsights.jmeter.ai.headless;
+
+/**
+ * Parsed command-line options for {@link HeadlessAiRunner}.
+ *
+ * <pre>
+ *   --cli &lt;name&gt;         CLI to use (default: kiro)
+ *   --prompt &lt;text&gt;      the request to send (or use --prompt-file)
+ *   --prompt-file &lt;path&gt; read the prompt from a file
+ *   --jmx &lt;path&gt;         test plan whose (redacted) content is shared as context
+ *   --working-dir &lt;path&gt; directory to run the CLI in (default: a temp dir)
+ *   --output &lt;path&gt;      report file (default: ./jmeter-ai-report.md)
+ *   --format md|json     report format (default: md)
+ *   --timeout &lt;seconds&gt;  wall-clock limit (default: 300)
+ *   --fail-on-error      exit non-zero if the CLI run fails
+ *   --help               print usage
+ * </pre>
+ */
+public final class HeadlessOptions {
+
+    public String cli = "kiro";
+    public String prompt;
+    public String promptFile;
+    public String jmx;
+    public String workingDir;
+    public String output = "jmeter-ai-report.md";
+    public String format = "md";
+    public long timeoutSeconds = 300;
+    public boolean failOnError;
+    public boolean help;
+
+    public static String usage() {
+        return "Usage: HeadlessAiRunner --prompt \"<text>\" [options]\n"
+                + "  --cli <name>          CLI to use (default: kiro)\n"
+                + "  --prompt <text>       request to send (or --prompt-file)\n"
+                + "  --prompt-file <path>  read the prompt from a file\n"
+                + "  --jmx <path>          test plan shared as (redacted) context\n"
+                + "  --working-dir <path>  directory to run the CLI in (default: temp)\n"
+                + "  --output <path>       report file (default: jmeter-ai-report.md)\n"
+                + "  --format md|json      report format (default: md)\n"
+                + "  --timeout <seconds>   wall-clock limit (default: 300)\n"
+                + "  --fail-on-error       exit non-zero if the CLI run fails\n"
+                + "  --help                print this help";
+    }
+
+    /**
+     * Parse argv into options.
+     *
+     * @throws HeadlessUsageException on an unknown flag or a missing value
+     */
+    public static HeadlessOptions parse(String[] args) {
+        HeadlessOptions o = new HeadlessOptions();
+        if (args == null) {
+            return o;
+        }
+        for (int i = 0; i < args.length; i++) {
+            String a = args[i];
+            switch (a) {
+                case "--help":
+                case "-h":
+                    o.help = true;
+                    break;
+                case "--fail-on-error":
+                    o.failOnError = true;
+                    break;
+                case "--cli":
+                    o.cli = value(args, ++i, a);
+                    break;
+                case "--prompt":
+                    o.prompt = value(args, ++i, a);
+                    break;
+                case "--prompt-file":
+                    o.promptFile = value(args, ++i, a);
+                    break;
+                case "--jmx":
+                    o.jmx = value(args, ++i, a);
+                    break;
+                case "--working-dir":
+                    o.workingDir = value(args, ++i, a);
+                    break;
+                case "--output":
+                    o.output = value(args, ++i, a);
+                    break;
+                case "--format":
+                    o.format = value(args, ++i, a).toLowerCase();
+                    if (!o.format.equals("md") && !o.format.equals("json")) {
+                        throw new HeadlessUsageException("--format must be 'md' or 'json'");
+                    }
+                    break;
+                case "--timeout":
+                    String t = value(args, ++i, a);
+                    try {
+                        o.timeoutSeconds = Long.parseLong(t.trim());
+                    } catch (NumberFormatException e) {
+                        throw new HeadlessUsageException("--timeout must be a number of seconds: " + t);
+                    }
+                    if (o.timeoutSeconds <= 0) {
+                        throw new HeadlessUsageException("--timeout must be positive");
+                    }
+                    break;
+                default:
+                    throw new HeadlessUsageException("Unknown argument: " + a);
+            }
+        }
+        return o;
+    }
+
+    private static String value(String[] args, int i, String flag) {
+        if (i >= args.length) {
+            throw new HeadlessUsageException("Missing value for " + flag);
+        }
+        return args[i];
+    }
+}

--- a/src/main/java/org/qainsights/jmeter/ai/headless/HeadlessReport.java
+++ b/src/main/java/org/qainsights/jmeter/ai/headless/HeadlessReport.java
@@ -1,0 +1,106 @@
+package org.qainsights.jmeter.ai.headless;
+
+import org.qainsights.jmeter.ai.security.AuditLogger;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Renders the artifact a headless run leaves behind for CI to archive and for
+ * humans to review in a pull request. Supports Markdown (default) and JSON.
+ */
+public final class HeadlessReport {
+
+    public final String cli;
+    public final String binary;
+    public final String prompt;
+    public final String jmx;
+    public final List<String> command;
+    public final int exitCode;
+    public final boolean timedOut;
+    public final String output;
+    public final String timestamp;
+
+    public HeadlessReport(String cli, String binary, String prompt, String jmx,
+                          List<String> command, int exitCode, boolean timedOut, String output) {
+        this.cli = nullToEmpty(cli);
+        this.binary = nullToEmpty(binary);
+        this.prompt = nullToEmpty(prompt);
+        this.jmx = nullToEmpty(jmx);
+        this.command = command;
+        this.exitCode = exitCode;
+        this.timedOut = timedOut;
+        this.output = nullToEmpty(output);
+        this.timestamp = Instant.now().toString();
+    }
+
+    public String status() {
+        if (timedOut) {
+            return "TIMED_OUT";
+        }
+        return exitCode == 0 ? "SUCCESS" : "FAILED";
+    }
+
+    public String render(String format) {
+        return "json".equalsIgnoreCase(format) ? toJson() : toMarkdown();
+    }
+
+    private String toMarkdown() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("# JMeter AI Headless Report\n\n");
+        sb.append("- **Status:** ").append(status()).append('\n');
+        sb.append("- **Exit code:** ").append(exitCode).append('\n');
+        sb.append("- **Timestamp:** ").append(timestamp).append('\n');
+        sb.append("- **CLI:** ").append(cli).append('\n');
+        sb.append("- **Binary:** ").append(binary).append('\n');
+        if (!jmx.isEmpty()) {
+            sb.append("- **Test plan:** ").append(jmx).append('\n');
+        }
+        sb.append("- **Command:** `").append(commandString()).append("`\n\n");
+        sb.append("## Prompt\n\n").append(prompt).append("\n\n");
+        sb.append("## Output\n\n```\n").append(output);
+        if (!output.endsWith("\n")) {
+            sb.append('\n');
+        }
+        sb.append("```\n");
+        return sb.toString();
+    }
+
+    private String toJson() {
+        StringBuilder sb = new StringBuilder();
+        sb.append('{');
+        jsonField(sb, "status", status());
+        sb.append(',');
+        sb.append("\"exitCode\":").append(exitCode);
+        sb.append(',');
+        sb.append("\"timedOut\":").append(timedOut);
+        sb.append(',');
+        jsonField(sb, "timestamp", timestamp);
+        sb.append(',');
+        jsonField(sb, "cli", cli);
+        sb.append(',');
+        jsonField(sb, "binary", binary);
+        sb.append(',');
+        jsonField(sb, "jmx", jmx);
+        sb.append(',');
+        jsonField(sb, "command", commandString());
+        sb.append(',');
+        jsonField(sb, "prompt", prompt);
+        sb.append(',');
+        jsonField(sb, "output", output);
+        sb.append('}');
+        return sb.toString();
+    }
+
+    private String commandString() {
+        return command == null ? "" : String.join(" ", command);
+    }
+
+    private static void jsonField(StringBuilder sb, String key, String value) {
+        sb.append('"').append(key).append("\":\"").append(AuditLogger.escape(value)).append('"');
+    }
+
+    private static String nullToEmpty(String s) {
+        return s == null ? "" : s;
+    }
+}

--- a/src/main/java/org/qainsights/jmeter/ai/headless/HeadlessUsageException.java
+++ b/src/main/java/org/qainsights/jmeter/ai/headless/HeadlessUsageException.java
@@ -1,0 +1,8 @@
+package org.qainsights.jmeter.ai.headless;
+
+/** Thrown when command-line arguments for the headless runner are invalid. */
+public class HeadlessUsageException extends RuntimeException {
+    public HeadlessUsageException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/qainsights/jmeter/ai/headless/ProcessRunner.java
+++ b/src/main/java/org/qainsights/jmeter/ai/headless/ProcessRunner.java
@@ -1,0 +1,35 @@
+package org.qainsights.jmeter.ai.headless;
+
+import java.io.File;
+import java.util.List;
+
+/**
+ * Seam for executing an external CLI process. Abstracted so the headless runner
+ * can be unit-tested with a fake instead of launching a real binary.
+ */
+public interface ProcessRunner {
+
+    /** Outcome of a process execution. */
+    final class Result {
+        public final int exitCode;
+        public final String output;
+        public final boolean timedOut;
+
+        public Result(int exitCode, String output, boolean timedOut) {
+            this.exitCode = exitCode;
+            this.output = output == null ? "" : output;
+            this.timedOut = timedOut;
+        }
+    }
+
+    /**
+     * Run {@code command} in {@code workingDir}, capturing combined stdout+stderr.
+     *
+     * @param command        full argv (argv[0] is the binary)
+     * @param workingDir     working directory (may be null = inherit)
+     * @param timeoutSeconds wall-clock limit; the process is killed if exceeded
+     * @param env            extra environment variables to set (may be null)
+     */
+    Result run(List<String> command, File workingDir, long timeoutSeconds,
+               java.util.Map<String, String> env) throws Exception;
+}

--- a/src/main/java/org/qainsights/jmeter/ai/mcp/McpConfigProvider.java
+++ b/src/main/java/org/qainsights/jmeter/ai/mcp/McpConfigProvider.java
@@ -1,0 +1,70 @@
+package org.qainsights.jmeter.ai.mcp;
+
+import org.qainsights.jmeter.ai.utils.AiConfig;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Builds the set of MCP servers to expose to the AI CLIs from JMeter properties.
+ *
+ * <p>The headline server is the <a href="https://github.com/QAInsights/jmeter-mcp-server">
+ * JMeter MCP server</a>, which is run as {@code uv --directory &lt;dir&gt; run
+ * jmeter_server.py}. It is only wired when an operator points at a local checkout
+ * via {@code jmeter.ai.mcp.jmeter.dir}, so the default behaviour writes nothing.
+ *
+ * <p>Properties:
+ * <ul>
+ *   <li>{@code jmeter.ai.mcp.enabled} (default true)</li>
+ *   <li>{@code jmeter.ai.mcp.jmeter.dir} — path to the jmeter-mcp-server checkout</li>
+ *   <li>{@code jmeter.ai.mcp.jmeter.command} (default {@code uv})</li>
+ *   <li>{@code jmeter.ai.mcp.jmeter.autoApprove} — comma list of tools to auto-approve</li>
+ * </ul>
+ */
+public final class McpConfigProvider {
+
+    public static final String ENABLED_PROP = "jmeter.ai.mcp.enabled";
+    public static final String JMETER_DIR_PROP = "jmeter.ai.mcp.jmeter.dir";
+    public static final String JMETER_CMD_PROP = "jmeter.ai.mcp.jmeter.command";
+    public static final String JMETER_AUTO_APPROVE_PROP = "jmeter.ai.mcp.jmeter.autoApprove";
+
+    private McpConfigProvider() {
+    }
+
+    public static boolean isEnabled() {
+        return AiConfig.getProperty(ENABLED_PROP, "true").equalsIgnoreCase("true");
+    }
+
+    /** @return the servers to write, or an empty list when nothing is configured. */
+    public static List<McpServerConfig> configuredServers() {
+        List<McpServerConfig> servers = new ArrayList<>();
+        if (!isEnabled()) {
+            return servers;
+        }
+
+        String dir = AiConfig.getProperty(JMETER_DIR_PROP, "").trim();
+        if (!dir.isEmpty()) {
+            String command = AiConfig.getProperty(JMETER_CMD_PROP, "uv").trim();
+            McpServerConfig jmeter = new McpServerConfig("jmeter", command)
+                    .args(Arrays.asList("--directory", dir, "run", "jmeter_server.py"))
+                    .autoApprove(splitCsv(AiConfig.getProperty(JMETER_AUTO_APPROVE_PROP, "")));
+            servers.add(jmeter);
+        }
+        return servers;
+    }
+
+    static List<String> splitCsv(String csv) {
+        List<String> out = new ArrayList<>();
+        if (csv == null) {
+            return out;
+        }
+        for (String part : csv.split(",")) {
+            String p = part.trim();
+            if (!p.isEmpty()) {
+                out.add(p);
+            }
+        }
+        return out;
+    }
+}

--- a/src/main/java/org/qainsights/jmeter/ai/mcp/McpConfigWriter.java
+++ b/src/main/java/org/qainsights/jmeter/ai/mcp/McpConfigWriter.java
@@ -1,0 +1,74 @@
+package org.qainsights.jmeter.ai.mcp;
+
+import org.qainsights.jmeter.ai.claudecode.BaseCliAdapter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Writes a CLI-specific MCP configuration file into the working (test-plan)
+ * directory so the launched agent can reach the configured MCP servers.
+ *
+ * <p>For Kiro this is {@code .kiro/settings/mcp.json}, in the standard
+ * {@code {"mcpServers": { ... }}} schema. The file is project-scoped (lives next
+ * to the {@code .jmx}), so it never disturbs the user's global config.
+ */
+public final class McpConfigWriter {
+
+    private static final Logger log = LoggerFactory.getLogger(McpConfigWriter.class);
+
+    private McpConfigWriter() {
+    }
+
+    /**
+     * Write MCP config for {@code adapter} into {@code workingDir}, if MCP is
+     * enabled, the CLI supports MCP, and at least one server is configured.
+     *
+     * @return the path written, or {@code null} if nothing was written.
+     */
+    public static Path writeFor(BaseCliAdapter adapter, File workingDir) {
+        if (adapter == null || workingDir == null || !adapter.supportsMcp()) {
+            return null;
+        }
+        String relative = adapter.mcpConfigRelativePath();
+        if (relative == null || relative.isEmpty()) {
+            return null;
+        }
+        List<McpServerConfig> servers = McpConfigProvider.configuredServers();
+        if (servers.isEmpty()) {
+            return null;
+        }
+        try {
+            Path target = new File(workingDir, relative).toPath();
+            if (target.getParent() != null) {
+                Files.createDirectories(target.getParent());
+            }
+            Files.write(target, render(servers).getBytes(StandardCharsets.UTF_8));
+            log.info("Wrote MCP config for {} to {} ({} server(s))",
+                    adapter.getName(), target, servers.size());
+            return target;
+        } catch (IOException e) {
+            log.warn("Could not write MCP config for {}: {}", adapter.getName(), e.getMessage());
+            return null;
+        }
+    }
+
+    /** Render the full {@code {"mcpServers": {...}}} document. */
+    public static String render(List<McpServerConfig> servers) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\n  \"mcpServers\": {\n");
+        for (int i = 0; i < servers.size(); i++) {
+            McpServerConfig s = servers.get(i);
+            sb.append("    \"").append(s.name()).append("\": ").append(s.toJsonObject());
+            sb.append(i < servers.size() - 1 ? ",\n" : "\n");
+        }
+        sb.append("  }\n}\n");
+        return sb.toString();
+    }
+}

--- a/src/main/java/org/qainsights/jmeter/ai/mcp/McpServerConfig.java
+++ b/src/main/java/org/qainsights/jmeter/ai/mcp/McpServerConfig.java
@@ -1,0 +1,100 @@
+package org.qainsights.jmeter.ai.mcp;
+
+import org.qainsights.jmeter.ai.security.AuditLogger;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * One MCP (Model Context Protocol) server entry, e.g. the JMeter MCP server that
+ * lets an AI agent actually run tests and parse JTLs through tools instead of
+ * free text. Rendered into the {@code mcpServers} object of a CLI's MCP config.
+ */
+public final class McpServerConfig {
+
+    private final String name;
+    private final String command;
+    private final List<String> args = new ArrayList<>();
+    private final Map<String, String> env = new LinkedHashMap<>();
+    private final List<String> autoApprove = new ArrayList<>();
+    private boolean disabled;
+
+    public McpServerConfig(String name, String command) {
+        this.name = name;
+        this.command = command;
+    }
+
+    public McpServerConfig args(List<String> a) {
+        if (a != null) {
+            this.args.addAll(a);
+        }
+        return this;
+    }
+
+    public McpServerConfig env(Map<String, String> e) {
+        if (e != null) {
+            this.env.putAll(e);
+        }
+        return this;
+    }
+
+    public McpServerConfig autoApprove(List<String> tools) {
+        if (tools != null) {
+            this.autoApprove.addAll(tools);
+        }
+        return this;
+    }
+
+    public McpServerConfig disabled(boolean d) {
+        this.disabled = d;
+        return this;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    /** Render this server as a JSON object body (the value under its name key). */
+    public String toJsonObject() {
+        StringBuilder sb = new StringBuilder();
+        sb.append('{');
+        sb.append("\"command\":\"").append(AuditLogger.escape(command)).append('"');
+        sb.append(",\"args\":").append(jsonStringArray(args));
+        if (!env.isEmpty()) {
+            sb.append(",\"env\":").append(jsonStringMap(env));
+        }
+        if (!autoApprove.isEmpty()) {
+            sb.append(",\"autoApprove\":").append(jsonStringArray(autoApprove));
+        }
+        sb.append(",\"disabled\":").append(disabled);
+        sb.append('}');
+        return sb.toString();
+    }
+
+    static String jsonStringArray(List<String> values) {
+        StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < values.size(); i++) {
+            if (i > 0) {
+                sb.append(',');
+            }
+            sb.append('"').append(AuditLogger.escape(values.get(i))).append('"');
+        }
+        return sb.append(']').toString();
+    }
+
+    static String jsonStringMap(Map<String, String> map) {
+        StringBuilder sb = new StringBuilder("{");
+        boolean first = true;
+        for (Map.Entry<String, String> e : map.entrySet()) {
+            if (!first) {
+                sb.append(',');
+            }
+            first = false;
+            sb.append('"').append(AuditLogger.escape(e.getKey())).append("\":\"")
+              .append(AuditLogger.escape(e.getValue())).append('"');
+        }
+        return sb.append('}').toString();
+    }
+}

--- a/src/main/java/org/qainsights/jmeter/ai/security/AuditLogger.java
+++ b/src/main/java/org/qainsights/jmeter/ai/security/AuditLogger.java
@@ -1,0 +1,189 @@
+package org.qainsights.jmeter.ai.security;
+
+import org.qainsights.jmeter.ai.utils.AiConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.security.MessageDigest;
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Append-only audit trail for AI CLI invocations.
+ *
+ * <p>Enterprises need to answer "who sent what to which AI, and when" for
+ * security reviews and compliance. Every time the embedded terminal launches an
+ * AI CLI, one JSON line is appended to the audit log capturing the actor, the
+ * CLI/binary, the resolved command (flags only — no secrets), the working
+ * directory, whether redaction was active, and a SHA-256 of the redacted context
+ * that was shared. The hash lets auditors prove exactly what was sent without
+ * the log itself ever storing the (potentially sensitive) content.
+ *
+ * <p>Enabled by default; controlled by {@code jmeter.ai.security.audit.enabled}.
+ * The destination is {@code jmeter.ai.security.audit.file}, defaulting to
+ * {@code <JMETER_HOME>/logs/jmeter-ai-audit.log} (or {@code ~/.jmeter-ai-audit.log}).
+ */
+public final class AuditLogger {
+
+    private static final Logger log = LoggerFactory.getLogger(AuditLogger.class);
+
+    private static final String ENABLED_PROP = "jmeter.ai.security.audit.enabled";
+    private static final String FILE_PROP = "jmeter.ai.security.audit.file";
+
+    private AuditLogger() {
+    }
+
+    public static boolean isEnabled() {
+        return AiConfig.getProperty(ENABLED_PROP, "true").equalsIgnoreCase("true");
+    }
+
+    /**
+     * Record one AI CLI launch. Never throws — auditing must not break the
+     * terminal; failures are logged via slf4j instead.
+     *
+     * @param cliName       display name of the CLI (e.g. "AWS Kiro")
+     * @param binaryPath    resolved binary path
+     * @param command       full argv (flags only; no secret values)
+     * @param workingDir    working directory shared with the CLI (may be null)
+     * @param sharedContext the redacted context text written for the CLI (may be null)
+     */
+    public static void recordLaunch(String cliName, String binaryPath, List<String> command,
+                                    String workingDir, String sharedContext) {
+        if (!isEnabled()) {
+            return;
+        }
+        try {
+            StringBuilder json = new StringBuilder(512);
+            json.append('{');
+            field(json, "timestamp", Instant.now().toString());
+            json.append(',');
+            field(json, "event", "ai_cli_launch");
+            json.append(',');
+            field(json, "user", System.getProperty("user.name", "unknown"));
+            json.append(',');
+            field(json, "host", hostName());
+            json.append(',');
+            field(json, "cli", cliName);
+            json.append(',');
+            field(json, "binary", binaryPath);
+            json.append(',');
+            field(json, "command", command == null ? "" : String.join(" ", command));
+            json.append(',');
+            field(json, "workingDir", workingDir);
+            json.append(',');
+            field(json, "redactionEnabled", String.valueOf(SecretRedactor.isEnabled()));
+            json.append(',');
+            field(json, "contextSha256", sha256(sharedContext));
+            json.append(',');
+            field(json, "contextBytes",
+                    String.valueOf(sharedContext == null ? 0 : sharedContext.getBytes(StandardCharsets.UTF_8).length));
+            json.append('}');
+
+            String line = json.toString();
+            log.info("AI audit: {}", line);
+            Path target = resolveAuditFile();
+            Files.write(target, (line + System.lineSeparator()).getBytes(StandardCharsets.UTF_8),
+                    StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+        } catch (Exception e) {
+            // Auditing is best-effort; never disrupt the user's session.
+            log.warn("Could not write AI audit entry: {}", e.getMessage());
+        }
+    }
+
+    private static Path resolveAuditFile() throws IOException {
+        String configured = AiConfig.getProperty(FILE_PROP, "").trim();
+        if (!configured.isEmpty()) {
+            Path p = Paths.get(expandHome(configured));
+            ensureParent(p);
+            return p;
+        }
+        String jmeterHome = System.getProperty("jmeter.home",
+                System.getenv().getOrDefault("JMETER_HOME", ""));
+        if (jmeterHome != null && !jmeterHome.trim().isEmpty()) {
+            Path logsDir = Paths.get(jmeterHome, "logs");
+            try {
+                Files.createDirectories(logsDir);
+                return logsDir.resolve("jmeter-ai-audit.log");
+            } catch (IOException ignored) {
+                // fall through to home directory
+            }
+        }
+        return Paths.get(System.getProperty("user.home", "."), ".jmeter-ai-audit.log");
+    }
+
+    private static void ensureParent(Path p) throws IOException {
+        Path parent = p.getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+    }
+
+    private static String hostName() {
+        try {
+            return InetAddress.getLocalHost().getHostName();
+        } catch (Exception e) {
+            return "unknown";
+        }
+    }
+
+    static String sha256(String text) {
+        if (text == null) {
+            return "";
+        }
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] digest = md.digest(text.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder(digest.length * 2);
+            for (byte b : digest) {
+                sb.append(Character.forDigit((b >> 4) & 0xF, 16));
+                sb.append(Character.forDigit(b & 0xF, 16));
+            }
+            return sb.toString();
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+    private static String expandHome(String path) {
+        if (path.equals("~") || path.startsWith("~/") || path.startsWith("~\\")) {
+            return System.getProperty("user.home", "") + path.substring(1);
+        }
+        return path;
+    }
+
+    private static void field(StringBuilder sb, String key, String value) {
+        sb.append('"').append(key).append("\":\"").append(escape(value)).append('"');
+    }
+
+    /** Minimal JSON string escaping (dependency-free). */
+    static String escape(String s) {
+        if (s == null) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder(s.length() + 8);
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '"':  sb.append("\\\""); break;
+                case '\\': sb.append("\\\\"); break;
+                case '\n': sb.append("\\n");  break;
+                case '\r': sb.append("\\r");  break;
+                case '\t': sb.append("\\t");  break;
+                default:
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/org/qainsights/jmeter/ai/security/AuditLogger.java
+++ b/src/main/java/org/qainsights/jmeter/ai/security/AuditLogger.java
@@ -162,8 +162,8 @@ public final class AuditLogger {
         sb.append('"').append(key).append("\":\"").append(escape(value)).append('"');
     }
 
-    /** Minimal JSON string escaping (dependency-free). */
-    static String escape(String s) {
+    /** Minimal JSON string escaping (dependency-free). Shared by report rendering. */
+    public static String escape(String s) {
         if (s == null) {
             return "";
         }

--- a/src/main/java/org/qainsights/jmeter/ai/security/SecretRedactor.java
+++ b/src/main/java/org/qainsights/jmeter/ai/security/SecretRedactor.java
@@ -1,0 +1,104 @@
+package org.qainsights.jmeter.ai.security;
+
+import org.qainsights.jmeter.ai.utils.AiConfig;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Masks secrets and credentials before any test-plan context is handed to an AI
+ * CLI (written to {@code CLAUDE.md} / {@code AGENTS.md} / {@code KIRO.md}).
+ *
+ * <p>JMeter test plans routinely embed passwords, bearer tokens, API keys, and
+ * other secrets in sampler fields, HTTP headers, and CSV data. Sending those to
+ * an external agent is the single biggest blocker to enterprise adoption, so
+ * redaction is <strong>enabled by default</strong> and can only be turned off
+ * explicitly via {@code jmeter.ai.security.redaction.enabled=false}.
+ *
+ * <p>Redaction is intentionally conservative-to-aggressive: over-masking is safe,
+ * under-masking leaks. Three layers are applied:
+ * <ol>
+ *   <li><b>Key-based</b> — any {@code name = value} / {@code "name": "value"} /
+ *       {@code name=value} whose key looks like a credential.</li>
+ *   <li><b>Bearer tokens</b> — {@code Authorization: Bearer &lt;token&gt;}.</li>
+ *   <li><b>JWTs</b> — {@code eyJ...}.{...}.{...} anywhere in the text.</li>
+ * </ol>
+ */
+public final class SecretRedactor {
+
+    public static final String MASK = "***REDACTED***";
+
+    private static final String ENABLED_PROP = "jmeter.ai.security.redaction.enabled";
+    /** Comma-separated extra key fragments to treat as secret, e.g. {@code pin,otp}. */
+    private static final String EXTRA_KEYS_PROP = "jmeter.ai.security.redaction.extra_keys";
+
+    private static final String BASE_KEYS =
+            "password|passwd|pwd|secret|secret[_-]?key|token|auth[_-]?token|api[_-]?key|apikey|"
+                    + "access[_-]?key|client[_-]?secret|authorization|bearer|credential|private[_-]?key|"
+                    + "connection[_-]?string|session[_-]?id|cookie";
+
+    private static final Pattern BEARER =
+            Pattern.compile("(?i)(bearer\\s+)[A-Za-z0-9._~+/=\\-]{6,}");
+    private static final Pattern JWT =
+            Pattern.compile("eyJ[A-Za-z0-9_-]{6,}\\.[A-Za-z0-9_-]{4,}\\.[A-Za-z0-9_-]{4,}");
+
+    private SecretRedactor() {
+    }
+
+    /** @return {@code true} unless an admin has explicitly disabled redaction. */
+    public static boolean isEnabled() {
+        return AiConfig.getProperty(ENABLED_PROP, "true").equalsIgnoreCase("true");
+    }
+
+    /**
+     * Redact secrets from {@code text}. Returns the input unchanged if redaction
+     * is disabled or the input is null/empty.
+     */
+    public static String redact(String text) {
+        if (text == null || text.isEmpty() || !isEnabled()) {
+            return text;
+        }
+        String result = text;
+
+        // 1) Key-based: <key><sep><value>. Keys may be dotted (e.g. HTTPSampler.password).
+        Pattern keyValue = Pattern.compile(
+                "(?i)([\\w.\\-]*(?:" + keywordAlternation() + ")[\\w.\\-]*[\"']?\\s*[:=]\\s*[\"']?)"
+                        + "([^\"'\\r\\n,;}<>&]+)");
+        result = replaceGroup2(result, keyValue);
+
+        // 2) Authorization: Bearer <token>
+        result = BEARER.matcher(result).replaceAll("$1" + Matcher.quoteReplacement(MASK));
+
+        // 3) Standalone JWTs
+        result = JWT.matcher(result).replaceAll(Matcher.quoteReplacement(MASK));
+
+        return result;
+    }
+
+    private static String keywordAlternation() {
+        String extra = AiConfig.getProperty(EXTRA_KEYS_PROP, "").trim();
+        if (extra.isEmpty()) {
+            return BASE_KEYS;
+        }
+        // Escape and OR-in the operator-supplied fragments.
+        StringBuilder sb = new StringBuilder(BASE_KEYS);
+        for (String frag : extra.split(",")) {
+            String f = frag.trim();
+            if (!f.isEmpty()) {
+                sb.append('|').append(Pattern.quote(f));
+            }
+        }
+        return sb.toString();
+    }
+
+    /** Replace capture group 2 (the value) with the mask, keeping the key prefix. */
+    private static String replaceGroup2(String input, Pattern pattern) {
+        Matcher m = pattern.matcher(input);
+        StringBuffer out = new StringBuffer();
+        while (m.find()) {
+            m.appendReplacement(out, Matcher.quoteReplacement(m.group(1) + MASK));
+        }
+        m.appendTail(out);
+        return out.toString();
+    }
+}

--- a/src/test/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapterTest.java
+++ b/src/test/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapterTest.java
@@ -143,12 +143,18 @@ class KiroCliAdapterTest {
     }
 
     private static void withProperty(String key, String value, Runnable body) {
-        String prev = org.apache.jmeter.util.JMeterUtils.getProperty(key);
+        String prev = JMeterUtils.getProperty(key);
         try {
-            org.apache.jmeter.util.JMeterUtils.setProperty(key, value);
+            JMeterUtils.setProperty(key, value);
             body.run();
         } finally {
-            org.apache.jmeter.util.JMeterUtils.setProperty(key, prev == null ? "" : prev);
+            // Remove (not blank out) when previously unset, so the default applies
+            // again regardless of test order.
+            if (prev == null) {
+                JMeterUtils.getJMeterProperties().remove(key);
+            } else {
+                JMeterUtils.setProperty(key, prev);
+            }
         }
     }
 }

--- a/src/test/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapterTest.java
+++ b/src/test/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapterTest.java
@@ -159,6 +159,18 @@ class KiroCliAdapterTest {
         assertEquals("", command.get(command.size() - 1));
     }
 
+    // ── MCP wiring ─────────────────────────────────────────────────────────────
+
+    @Test
+    void supportsMcp_isTrue() {
+        assertTrue(new KiroCliAdapter().supportsMcp());
+    }
+
+    @Test
+    void mcpConfigRelativePath_isKiroWorkspaceSettings() {
+        assertEquals(".kiro/settings/mcp.json", new KiroCliAdapter().mcpConfigRelativePath());
+    }
+
     private static KiroCliAdapter detectedAdapter(String binary) {
         KiroCliAdapter adapter = new KiroCliAdapter() {
             @Override

--- a/src/test/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapterTest.java
+++ b/src/test/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapterTest.java
@@ -1,0 +1,96 @@
+package org.qainsights.jmeter.ai.claudecode;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link KiroCliAdapter}.
+ * <p>
+ * The protected {@link BaseCliAdapter#findOnPath(String)} is overridden in
+ * anonymous subclasses so tests never invoke a real system process.
+ */
+class KiroCliAdapterTest {
+
+    // ── getName ────────────────────────────────────────────────────────────────
+
+    @Test
+    void getName_returnsAwsKiro() {
+        assertEquals("AWS Kiro", new KiroCliAdapter().getName());
+    }
+
+    @Test
+    void toString_returnsAwsKiro() {
+        assertEquals("AWS Kiro", new KiroCliAdapter().toString());
+    }
+
+    // ── getBinaryPath before detect ────────────────────────────────────────────
+
+    @Test
+    void getBinaryPath_returnsNullBeforeDetect() {
+        assertNull(new KiroCliAdapter().getBinaryPath());
+    }
+
+    // ── detect ─────────────────────────────────────────────────────────────────
+
+    @Test
+    void detect_whenKiroCliOnPath_returnsTrueAndSetsPath() {
+        KiroCliAdapter adapter = new KiroCliAdapter() {
+            @Override
+            protected String findOnPath(String binaryName) {
+                return "kiro-cli".equals(binaryName) ? "/home/me/.kiro/bin/kiro-cli" : null;
+            }
+        };
+        assertTrue(adapter.detect());
+        assertEquals("/home/me/.kiro/bin/kiro-cli", adapter.getBinaryPath());
+    }
+
+    @Test
+    void detect_prefersKiroCliOverShortKiroAlias() {
+        String[] firstQueried = {null};
+        KiroCliAdapter adapter = new KiroCliAdapter() {
+            @Override
+            protected String findOnPath(String binaryName) {
+                if (firstQueried[0] == null) {
+                    firstQueried[0] = binaryName;
+                }
+                return null;
+            }
+        };
+        adapter.detect();
+        assertEquals("kiro-cli", firstQueried[0]);
+    }
+
+    @Test
+    void detect_fallsBackToKiroAliasWhenKiroCliMissing() {
+        KiroCliAdapter adapter = new KiroCliAdapter() {
+            @Override
+            protected String findOnPath(String binaryName) {
+                return "kiro".equals(binaryName) ? "/usr/local/bin/kiro" : null;
+            }
+        };
+        assertTrue(adapter.detect());
+        assertEquals("/usr/local/bin/kiro", adapter.getBinaryPath());
+    }
+
+    // ── buildCommand ───────────────────────────────────────────────────────────
+
+    @Test
+    void buildCommand_afterDetect_appendsChatSubcommand() {
+        KiroCliAdapter adapter = new KiroCliAdapter() {
+            @Override
+            protected String findOnPath(String binaryName) {
+                return "/usr/local/bin/kiro-cli";
+            }
+        };
+        adapter.detect();
+
+        List<String> command = adapter.buildCommand(null);
+
+        assertEquals(2, command.size());
+        assertEquals("/usr/local/bin/kiro-cli", command.get(0));
+        assertEquals("chat", command.get(1));
+    }
+}

--- a/src/test/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapterTest.java
+++ b/src/test/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapterTest.java
@@ -131,6 +131,34 @@ class KiroCliAdapterTest {
         });
     }
 
+    // ── headless mode ──────────────────────────────────────────────────────────
+
+    @Test
+    void supportsHeadless_isTrue() {
+        assertTrue(new KiroCliAdapter().supportsHeadless());
+    }
+
+    @Test
+    void buildHeadlessCommand_includesNoInteractiveTrustAndPrompt() {
+        KiroCliAdapter adapter = detectedAdapter("/usr/local/bin/kiro-cli");
+
+        List<String> command = adapter.buildHeadlessCommand("Lint this plan", null);
+
+        assertEquals("/usr/local/bin/kiro-cli", command.get(0));
+        assertEquals("chat", command.get(1));
+        assertTrue(command.contains("--no-interactive"), command.toString());
+        assertTrue(command.contains("--trust-tools=read,grep,fs_read"), command.toString());
+        assertEquals("Lint this plan", command.get(command.size() - 1),
+                "prompt must be the final argument");
+    }
+
+    @Test
+    void buildHeadlessCommand_nullPromptBecomesEmptyArg() {
+        KiroCliAdapter adapter = detectedAdapter("/usr/local/bin/kiro-cli");
+        List<String> command = adapter.buildHeadlessCommand(null, null);
+        assertEquals("", command.get(command.size() - 1));
+    }
+
     private static KiroCliAdapter detectedAdapter(String binary) {
         KiroCliAdapter adapter = new KiroCliAdapter() {
             @Override

--- a/src/test/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapterTest.java
+++ b/src/test/java/org/qainsights/jmeter/ai/claudecode/KiroCliAdapterTest.java
@@ -1,7 +1,11 @@
 package org.qainsights.jmeter.ai.claudecode;
 
+import org.apache.jmeter.util.JMeterUtils;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -13,6 +17,16 @@ import static org.junit.jupiter.api.Assertions.*;
  * anonymous subclasses so tests never invoke a real system process.
  */
 class KiroCliAdapterTest {
+
+    @BeforeAll
+    static void initJMeterProperties() throws IOException {
+        // setProperty needs an initialized properties object; load an empty one.
+        if (JMeterUtils.getJMeterProperties() == null) {
+            File tmp = File.createTempFile("jmeter-test", ".properties");
+            tmp.deleteOnExit();
+            JMeterUtils.loadJMeterProperties(tmp.getAbsolutePath());
+        }
+    }
 
     // ── getName ────────────────────────────────────────────────────────────────
 
@@ -79,18 +93,62 @@ class KiroCliAdapterTest {
 
     @Test
     void buildCommand_afterDetect_appendsChatSubcommand() {
-        KiroCliAdapter adapter = new KiroCliAdapter() {
-            @Override
-            protected String findOnPath(String binaryName) {
-                return "/usr/local/bin/kiro-cli";
-            }
-        };
-        adapter.detect();
+        KiroCliAdapter adapter = detectedAdapter("/usr/local/bin/kiro-cli");
 
         List<String> command = adapter.buildCommand(null);
 
-        assertEquals(2, command.size());
         assertEquals("/usr/local/bin/kiro-cli", command.get(0));
         assertEquals("chat", command.get(1));
+    }
+
+    // ── tool-trust policy ──────────────────────────────────────────────────────
+
+    @Test
+    void buildCommand_byDefault_restrictsToReadOnlyTrustedTools() {
+        KiroCliAdapter adapter = detectedAdapter("/usr/local/bin/kiro-cli");
+
+        List<String> command = adapter.buildCommand(null);
+
+        assertTrue(command.contains("--trust-tools=read,grep,fs_read"),
+                "default policy must trust only read-only tools: " + command);
+        assertFalse(command.contains("--trust-all-tools"));
+    }
+
+    @Test
+    void buildCommand_whenTrustAllToolsEnabled_usesTrustAllFlag() {
+        withProperty("jmeter.ai.terminal.kiro.trust_all_tools", "true", () -> {
+            List<String> command = detectedAdapter("/usr/local/bin/kiro-cli").buildCommand(null);
+            assertTrue(command.contains("--trust-all-tools"), command.toString());
+            assertFalse(command.stream().anyMatch(s -> s.startsWith("--trust-tools=")));
+        });
+    }
+
+    @Test
+    void buildCommand_whenTrustToolsBlank_omitsTrustFlag() {
+        withProperty("jmeter.ai.terminal.kiro.trust_tools", "", () -> {
+            List<String> command = detectedAdapter("/usr/local/bin/kiro-cli").buildCommand(null);
+            assertFalse(command.stream().anyMatch(s -> s.startsWith("--trust-tools")), command.toString());
+        });
+    }
+
+    private static KiroCliAdapter detectedAdapter(String binary) {
+        KiroCliAdapter adapter = new KiroCliAdapter() {
+            @Override
+            protected String findOnPath(String binaryName) {
+                return binary;
+            }
+        };
+        adapter.detect();
+        return adapter;
+    }
+
+    private static void withProperty(String key, String value, Runnable body) {
+        String prev = org.apache.jmeter.util.JMeterUtils.getProperty(key);
+        try {
+            org.apache.jmeter.util.JMeterUtils.setProperty(key, value);
+            body.run();
+        } finally {
+            org.apache.jmeter.util.JMeterUtils.setProperty(key, prev == null ? "" : prev);
+        }
     }
 }

--- a/src/test/java/org/qainsights/jmeter/ai/headless/HeadlessAiRunnerTest.java
+++ b/src/test/java/org/qainsights/jmeter/ai/headless/HeadlessAiRunnerTest.java
@@ -1,0 +1,135 @@
+package org.qainsights.jmeter.ai.headless;
+
+import org.apache.jmeter.util.JMeterUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.qainsights.jmeter.ai.claudecode.BaseCliAdapter;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HeadlessAiRunnerTest {
+
+    @BeforeAll
+    static void initProps() throws IOException {
+        if (JMeterUtils.getJMeterProperties() == null) {
+            File tmp = File.createTempFile("jmeter-test", ".properties");
+            tmp.deleteOnExit();
+            JMeterUtils.loadJMeterProperties(tmp.getAbsolutePath());
+        }
+        // Keep audit writes out of the home directory during tests.
+        File audit = File.createTempFile("audit", ".log");
+        audit.deleteOnExit();
+        JMeterUtils.setProperty("jmeter.ai.security.audit.file", audit.getAbsolutePath());
+    }
+
+    @Test
+    void successReturnsZeroAndWritesReport(@TempDir Path dir) throws Exception {
+        HeadlessOptions o = options(dir, false);
+        int code = new HeadlessAiRunner().run(o, fixedRunner(0, "AI says hello", false),
+                adapter(true, true));
+
+        assertEquals(HeadlessAiRunner.EXIT_OK, code);
+        String report = read(o.output);
+        assertTrue(report.contains("SUCCESS"), report);
+        assertTrue(report.contains("AI says hello"), report);
+    }
+
+    @Test
+    void failureWithoutFailOnErrorStillReturnsZero(@TempDir Path dir) throws Exception {
+        HeadlessOptions o = options(dir, false);
+        int code = new HeadlessAiRunner().run(o, fixedRunner(2, "boom", false), adapter(true, true));
+        assertEquals(HeadlessAiRunner.EXIT_OK, code);
+        assertTrue(read(o.output).contains("FAILED"));
+    }
+
+    @Test
+    void failureWithFailOnErrorPropagatesExitCode(@TempDir Path dir) throws Exception {
+        HeadlessOptions o = options(dir, true);
+        int code = new HeadlessAiRunner().run(o, fixedRunner(2, "boom", false), adapter(true, true));
+        assertEquals(2, code);
+    }
+
+    @Test
+    void timeoutWithFailOnErrorReturnsTimeoutCode(@TempDir Path dir) throws Exception {
+        HeadlessOptions o = options(dir, true);
+        int code = new HeadlessAiRunner().run(o, fixedRunner(124, "", true), adapter(true, true));
+        assertEquals(HeadlessAiRunner.EXIT_TIMEOUT, code);
+    }
+
+    @Test
+    void cliNotFoundReturnsNotFoundCode(@TempDir Path dir) throws Exception {
+        HeadlessOptions o = options(dir, false);
+        int code = new HeadlessAiRunner().run(o, fixedRunner(0, "", false), adapter(false, true));
+        assertEquals(HeadlessAiRunner.EXIT_CLI_NOT_FOUND, code);
+    }
+
+    @Test
+    void unsupportedHeadlessReturnsUnsupportedCode(@TempDir Path dir) throws Exception {
+        HeadlessOptions o = options(dir, false);
+        int code = new HeadlessAiRunner().run(o, fixedRunner(0, "", false), adapter(true, false));
+        assertEquals(HeadlessAiRunner.EXIT_HEADLESS_UNSUPPORTED, code);
+    }
+
+    @Test
+    void missingPromptThrowsUsage(@TempDir Path dir) {
+        HeadlessOptions o = options(dir, false);
+        o.prompt = null;
+        assertThrows(HeadlessUsageException.class,
+                () -> new HeadlessAiRunner().run(o, fixedRunner(0, "", false), adapter(true, true)));
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static String read(String path) throws IOException {
+        return new String(Files.readAllBytes(Paths.get(path)), StandardCharsets.UTF_8);
+    }
+
+    private static HeadlessOptions options(Path dir, boolean failOnError) {
+        HeadlessOptions o = new HeadlessOptions();
+        o.prompt = "analyze the plan";
+        o.workingDir = dir.resolve("work").toString();
+        o.output = dir.resolve("report.md").toString();
+        o.failOnError = failOnError;
+        return o;
+    }
+
+    private static ProcessRunner fixedRunner(int exit, String output, boolean timedOut) {
+        return (command, workingDir, timeoutSeconds, env) ->
+                new ProcessRunner.Result(exit, output, timedOut);
+    }
+
+    private static BaseCliAdapter adapter(boolean detect, boolean headless) {
+        return new BaseCliAdapter() {
+            @Override
+            public String getName() {
+                return "FakeKiro";
+            }
+
+            @Override
+            public boolean detect() {
+                detectedPath = "/usr/local/bin/fake-kiro";
+                return detect;
+            }
+
+            @Override
+            public boolean supportsHeadless() {
+                return headless;
+            }
+
+            @Override
+            public List<String> buildHeadlessCommand(String prompt, String workingDirectory) {
+                return Arrays.asList("/usr/local/bin/fake-kiro", "chat", "--no-interactive", prompt);
+            }
+        };
+    }
+}

--- a/src/test/java/org/qainsights/jmeter/ai/headless/HeadlessOptionsTest.java
+++ b/src/test/java/org/qainsights/jmeter/ai/headless/HeadlessOptionsTest.java
@@ -1,0 +1,67 @@
+package org.qainsights.jmeter.ai.headless;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HeadlessOptionsTest {
+
+    @Test
+    void defaults_areSensible() {
+        HeadlessOptions o = HeadlessOptions.parse(new String[]{});
+        assertEquals("kiro", o.cli);
+        assertEquals("jmeter-ai-report.md", o.output);
+        assertEquals("md", o.format);
+        assertEquals(300, o.timeoutSeconds);
+        assertFalse(o.failOnError);
+        assertFalse(o.help);
+    }
+
+    @Test
+    void parsesAllFlags() {
+        HeadlessOptions o = HeadlessOptions.parse(new String[]{
+                "--cli", "kiro", "--prompt", "do it", "--jmx", "t.jmx",
+                "--working-dir", "/tmp/x", "--output", "r.json", "--format", "json",
+                "--timeout", "60", "--fail-on-error"});
+        assertEquals("do it", o.prompt);
+        assertEquals("t.jmx", o.jmx);
+        assertEquals("/tmp/x", o.workingDir);
+        assertEquals("r.json", o.output);
+        assertEquals("json", o.format);
+        assertEquals(60, o.timeoutSeconds);
+        assertTrue(o.failOnError);
+    }
+
+    @Test
+    void helpFlagSetsHelp() {
+        assertTrue(HeadlessOptions.parse(new String[]{"--help"}).help);
+        assertTrue(HeadlessOptions.parse(new String[]{"-h"}).help);
+    }
+
+    @Test
+    void unknownArgumentThrows() {
+        HeadlessUsageException e = assertThrows(HeadlessUsageException.class,
+                () -> HeadlessOptions.parse(new String[]{"--bogus"}));
+        assertTrue(e.getMessage().contains("Unknown argument"));
+    }
+
+    @Test
+    void missingValueThrows() {
+        assertThrows(HeadlessUsageException.class,
+                () -> HeadlessOptions.parse(new String[]{"--prompt"}));
+    }
+
+    @Test
+    void invalidFormatThrows() {
+        assertThrows(HeadlessUsageException.class,
+                () -> HeadlessOptions.parse(new String[]{"--format", "xml"}));
+    }
+
+    @Test
+    void invalidTimeoutThrows() {
+        assertThrows(HeadlessUsageException.class,
+                () -> HeadlessOptions.parse(new String[]{"--timeout", "abc"}));
+        assertThrows(HeadlessUsageException.class,
+                () -> HeadlessOptions.parse(new String[]{"--timeout", "0"}));
+    }
+}

--- a/src/test/java/org/qainsights/jmeter/ai/headless/HeadlessReportTest.java
+++ b/src/test/java/org/qainsights/jmeter/ai/headless/HeadlessReportTest.java
@@ -1,0 +1,49 @@
+package org.qainsights.jmeter.ai.headless;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HeadlessReportTest {
+
+    @Test
+    void status_reflectsExitAndTimeout() {
+        assertEquals("SUCCESS", report(0, false).status());
+        assertEquals("FAILED", report(2, false).status());
+        assertEquals("TIMED_OUT", report(124, true).status());
+    }
+
+    @Test
+    void markdown_containsKeySections() {
+        String md = report(0, false).render("md");
+        assertTrue(md.contains("# JMeter AI Headless Report"), md);
+        assertTrue(md.contains("**Status:** SUCCESS"), md);
+        assertTrue(md.contains("## Prompt"), md);
+        assertTrue(md.contains("## Output"), md);
+        assertTrue(md.contains("analyze this"), md);
+        assertTrue(md.contains("kiro-cli chat --no-interactive"), md);
+    }
+
+    @Test
+    void json_isWellFormedAndEscaped() {
+        HeadlessReport r = new HeadlessReport("AWS Kiro", "/bin/kiro-cli",
+                "say \"hi\"\nnow", "t.jmx",
+                Arrays.asList("/bin/kiro-cli", "chat"), 0, false, "line1\nline2");
+        String json = r.render("json");
+        assertTrue(json.startsWith("{") && json.endsWith("}"), json);
+        assertTrue(json.contains("\"status\":\"SUCCESS\""), json);
+        assertTrue(json.contains("\"exitCode\":0"), json);
+        assertTrue(json.contains("\"timedOut\":false"), json);
+        // quotes and newlines escaped, not raw
+        assertTrue(json.contains("say \\\"hi\\\"\\nnow"), json);
+        assertFalse(json.contains("line1\nline2"), "raw newline must be escaped");
+    }
+
+    private static HeadlessReport report(int exit, boolean timedOut) {
+        return new HeadlessReport("AWS Kiro", "/bin/kiro-cli", "analyze this", "t.jmx",
+                Arrays.asList("/bin/kiro-cli", "chat", "--no-interactive", "analyze this"),
+                exit, timedOut, "some output");
+    }
+}

--- a/src/test/java/org/qainsights/jmeter/ai/mcp/McpConfigProviderTest.java
+++ b/src/test/java/org/qainsights/jmeter/ai/mcp/McpConfigProviderTest.java
@@ -1,0 +1,65 @@
+package org.qainsights.jmeter.ai.mcp;
+
+import org.apache.jmeter.util.JMeterUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class McpConfigProviderTest {
+
+    @BeforeAll
+    static void initProps() throws IOException {
+        if (JMeterUtils.getJMeterProperties() == null) {
+            File tmp = File.createTempFile("jmeter-test", ".properties");
+            tmp.deleteOnExit();
+            JMeterUtils.loadJMeterProperties(tmp.getAbsolutePath());
+        }
+    }
+
+    @Test
+    void noJmeterDir_yieldsNoServers() {
+        // dir unset by default -> nothing to wire
+        assertTrue(McpConfigProvider.configuredServers().isEmpty());
+    }
+
+    @Test
+    void withJmeterDir_buildsJmeterServer() {
+        withProperty(McpConfigProvider.JMETER_DIR_PROP, "/srv/jmeter-mcp", () ->
+                withProperty(McpConfigProvider.JMETER_AUTO_APPROVE_PROP, "execute_jmeter_test", () -> {
+                    List<McpServerConfig> servers = McpConfigProvider.configuredServers();
+                    assertEquals(1, servers.size());
+                    String json = servers.get(0).toJsonObject();
+                    assertEquals("jmeter", servers.get(0).name());
+                    assertTrue(json.contains("\"command\":\"uv\""), json);
+                    assertTrue(json.contains("/srv/jmeter-mcp"), json);
+                    assertTrue(json.contains("jmeter_server.py"), json);
+                    assertTrue(json.contains("execute_jmeter_test"), json);
+                }));
+    }
+
+    @Test
+    void disabledFlag_yieldsNoServers() {
+        withProperty(McpConfigProvider.JMETER_DIR_PROP, "/srv/jmeter-mcp", () ->
+                withProperty(McpConfigProvider.ENABLED_PROP, "false", () ->
+                        assertTrue(McpConfigProvider.configuredServers().isEmpty())));
+    }
+
+    static void withProperty(String key, String value, Runnable body) {
+        String prev = JMeterUtils.getProperty(key);
+        try {
+            JMeterUtils.setProperty(key, value);
+            body.run();
+        } finally {
+            if (prev == null) {
+                JMeterUtils.getJMeterProperties().remove(key);
+            } else {
+                JMeterUtils.setProperty(key, prev);
+            }
+        }
+    }
+}

--- a/src/test/java/org/qainsights/jmeter/ai/mcp/McpConfigWriterTest.java
+++ b/src/test/java/org/qainsights/jmeter/ai/mcp/McpConfigWriterTest.java
@@ -1,0 +1,81 @@
+package org.qainsights.jmeter.ai.mcp;
+
+import org.apache.jmeter.util.JMeterUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.qainsights.jmeter.ai.claudecode.BaseCliAdapter;
+import org.qainsights.jmeter.ai.claudecode.KiroCliAdapter;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class McpConfigWriterTest {
+
+    @BeforeAll
+    static void initProps() throws IOException {
+        if (JMeterUtils.getJMeterProperties() == null) {
+            File tmp = File.createTempFile("jmeter-test", ".properties");
+            tmp.deleteOnExit();
+            JMeterUtils.loadJMeterProperties(tmp.getAbsolutePath());
+        }
+    }
+
+    @Test
+    void render_producesMcpServersDocument() {
+        List<McpServerConfig> servers = Collections.singletonList(
+                new McpServerConfig("jmeter", "uv")
+                        .args(Arrays.asList("--directory", "/srv", "run", "jmeter_server.py")));
+        String doc = McpConfigWriter.render(servers);
+        assertTrue(doc.contains("\"mcpServers\""), doc);
+        assertTrue(doc.contains("\"jmeter\""), doc);
+        assertTrue(doc.trim().startsWith("{") && doc.trim().endsWith("}"), doc);
+    }
+
+    @Test
+    void writeFor_kiroAdapter_writesWorkspaceMcpJson(@TempDir Path dir) throws IOException {
+        McpConfigProviderTest.withProperty(McpConfigProvider.JMETER_DIR_PROP, "/srv/jmeter-mcp", () -> {
+            Path written = McpConfigWriter.writeFor(new KiroCliAdapter(), dir.toFile());
+            assertNotNull(written);
+            assertTrue(written.endsWith(Paths.get(".kiro", "settings", "mcp.json")), written.toString());
+        });
+
+        Path expected = dir.resolve(".kiro").resolve("settings").resolve("mcp.json");
+        assertTrue(Files.exists(expected));
+        String content = new String(Files.readAllBytes(expected), StandardCharsets.UTF_8);
+        assertTrue(content.contains("\"jmeter\""), content);
+        assertTrue(content.contains("/srv/jmeter-mcp"), content);
+    }
+
+    @Test
+    void writeFor_returnsNullWhenNoServersConfigured(@TempDir Path dir) {
+        // No jmeter.dir set -> nothing configured -> nothing written.
+        assertNull(McpConfigWriter.writeFor(new KiroCliAdapter(), dir.toFile()));
+    }
+
+    @Test
+    void writeFor_returnsNullWhenAdapterDoesNotSupportMcp(@TempDir Path dir) {
+        BaseCliAdapter noMcp = new BaseCliAdapter() {
+            @Override
+            public String getName() {
+                return "NoMcpCli";
+            }
+
+            @Override
+            public boolean detect() {
+                return true;
+            }
+        };
+        McpConfigProviderTest.withProperty(McpConfigProvider.JMETER_DIR_PROP, "/srv/jmeter-mcp", () ->
+                assertNull(McpConfigWriter.writeFor(noMcp, dir.toFile())));
+    }
+}

--- a/src/test/java/org/qainsights/jmeter/ai/mcp/McpServerConfigTest.java
+++ b/src/test/java/org/qainsights/jmeter/ai/mcp/McpServerConfigTest.java
@@ -1,0 +1,52 @@
+package org.qainsights.jmeter.ai.mcp;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class McpServerConfigTest {
+
+    @Test
+    void rendersCommandAndArgs() {
+        String json = new McpServerConfig("jmeter", "uv")
+                .args(Arrays.asList("--directory", "/srv/jmeter-mcp", "run", "jmeter_server.py"))
+                .toJsonObject();
+
+        assertTrue(json.contains("\"command\":\"uv\""), json);
+        assertTrue(json.contains("\"args\":[\"--directory\",\"/srv/jmeter-mcp\",\"run\",\"jmeter_server.py\"]"), json);
+        assertTrue(json.contains("\"disabled\":false"), json);
+        // env / autoApprove omitted when empty
+        assertFalse(json.contains("\"env\""), json);
+        assertFalse(json.contains("\"autoApprove\""), json);
+    }
+
+    @Test
+    void rendersEnvAutoApproveAndDisabled() {
+        Map<String, String> env = new LinkedHashMap<>();
+        env.put("JMETER_HOME", "/opt/jmeter");
+        String json = new McpServerConfig("jmeter", "uv")
+                .args(Collections.singletonList("run"))
+                .env(env)
+                .autoApprove(Arrays.asList("execute_jmeter_test", "analyze_jtl"))
+                .disabled(true)
+                .toJsonObject();
+
+        assertTrue(json.contains("\"env\":{\"JMETER_HOME\":\"/opt/jmeter\"}"), json);
+        assertTrue(json.contains("\"autoApprove\":[\"execute_jmeter_test\",\"analyze_jtl\"]"), json);
+        assertTrue(json.contains("\"disabled\":true"), json);
+    }
+
+    @Test
+    void escapesSpecialCharacters() {
+        String json = new McpServerConfig("x", "C:\\tools\\uv.exe")
+                .args(Collections.singletonList("a\"b"))
+                .toJsonObject();
+        assertTrue(json.contains("C:\\\\tools\\\\uv.exe"), json);
+        assertTrue(json.contains("a\\\"b"), json);
+    }
+}

--- a/src/test/java/org/qainsights/jmeter/ai/security/AuditLoggerTest.java
+++ b/src/test/java/org/qainsights/jmeter/ai/security/AuditLoggerTest.java
@@ -1,0 +1,96 @@
+package org.qainsights.jmeter.ai.security;
+
+import org.apache.jmeter.util.JMeterUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link AuditLogger}. Exercises JSON encoding, the content hash,
+ * and end-to-end append behaviour against a temp audit file.
+ */
+class AuditLoggerTest {
+
+    @BeforeAll
+    static void initJMeterProperties() throws IOException {
+        if (JMeterUtils.getJMeterProperties() == null) {
+            File tmp = File.createTempFile("jmeter-test", ".properties");
+            tmp.deleteOnExit();
+            JMeterUtils.loadJMeterProperties(tmp.getAbsolutePath());
+        }
+    }
+
+    @Test
+    void escape_handlesQuotesNewlinesAndControlChars() {
+        assertEquals("a\\\"b", AuditLogger.escape("a\"b"));
+        assertEquals("line1\\nline2", AuditLogger.escape("line1\nline2"));
+        assertEquals("", AuditLogger.escape(null));
+    }
+
+    @Test
+    void sha256_isStableAndHex() {
+        String a = AuditLogger.sha256("hello");
+        String b = AuditLogger.sha256("hello");
+        assertEquals(a, b);
+        assertEquals(64, a.length());
+        assertTrue(a.matches("[0-9a-f]{64}"));
+        assertNotEquals(a, AuditLogger.sha256("world"));
+        assertEquals("", AuditLogger.sha256(null));
+    }
+
+    @Test
+    void recordLaunch_appendsOneJsonLineWithExpectedFields(@TempDir Path dir) throws IOException {
+        Path audit = dir.resolve("audit.log");
+        withProperty("jmeter.ai.security.audit.file", audit.toString(), () -> {
+            List<String> command = Arrays.asList("/usr/local/bin/kiro-cli", "chat",
+                    "--trust-tools=read,grep,fs_read");
+            AuditLogger.recordLaunch("AWS Kiro", "/usr/local/bin/kiro-cli", command,
+                    "/work/dir", "  | HTTPSampler.path = /api");
+        });
+
+        List<String> lines = Files.readAllLines(audit);
+        assertEquals(1, lines.size());
+        String line = lines.get(0);
+        assertTrue(line.startsWith("{") && line.endsWith("}"), line);
+        assertTrue(line.contains("\"event\":\"ai_cli_launch\""), line);
+        assertTrue(line.contains("\"cli\":\"AWS Kiro\""), line);
+        assertTrue(line.contains("--trust-tools=read,grep,fs_read"), line);
+        assertTrue(line.contains("\"contextSha256\":\""), line);
+        assertFalse(line.contains("\n\n"));
+    }
+
+    @Test
+    void recordLaunch_whenDisabled_writesNothing(@TempDir Path dir) throws IOException {
+        Path audit = dir.resolve("audit-disabled.log");
+        withProperty("jmeter.ai.security.audit.enabled", "false", () ->
+                withProperty("jmeter.ai.security.audit.file", audit.toString(), () ->
+                        AuditLogger.recordLaunch("AWS Kiro", "/bin/kiro-cli",
+                                Arrays.asList("/bin/kiro-cli", "chat"), "/work", "ctx")));
+        assertFalse(Files.exists(audit), "no audit file should be created when disabled");
+    }
+
+    private static void withProperty(String key, String value, Runnable body) {
+        String prev = JMeterUtils.getProperty(key);
+        try {
+            JMeterUtils.setProperty(key, value);
+            body.run();
+        } finally {
+            // Remove (not blank out) when the key was previously unset, so the
+            // configured default applies again regardless of test order.
+            if (prev == null) {
+                JMeterUtils.getJMeterProperties().remove(key);
+            } else {
+                JMeterUtils.setProperty(key, prev);
+            }
+        }
+    }
+}

--- a/src/test/java/org/qainsights/jmeter/ai/security/SecretRedactorTest.java
+++ b/src/test/java/org/qainsights/jmeter/ai/security/SecretRedactorTest.java
@@ -1,0 +1,67 @@
+package org.qainsights.jmeter.ai.security;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link SecretRedactor}. Redaction is on by default (no JMeter
+ * properties loaded), so these exercise the default-enabled behaviour.
+ */
+class SecretRedactorTest {
+
+    @Test
+    void masksPropertyStyleSecretButKeepsKey() {
+        String in = "  | HTTPSampler.password = s3cr3tV4lue\n  | HTTPSampler.path = /api/login";
+        String out = SecretRedactor.redact(in);
+
+        assertFalse(out.contains("s3cr3tV4lue"), out);
+        assertTrue(out.contains("HTTPSampler.password = " + SecretRedactor.MASK), out);
+        // Non-secret values are untouched.
+        assertTrue(out.contains("/api/login"), out);
+    }
+
+    @Test
+    void masksJsonStyleTokenField() {
+        String in = "{\"api_key\":\"AKIA1234567890\",\"region\":\"us-east-1\"}";
+        String out = SecretRedactor.redact(in);
+
+        assertFalse(out.contains("AKIA1234567890"), out);
+        assertTrue(out.contains("us-east-1"), out);
+    }
+
+    @Test
+    void masksBearerToken() {
+        String in = "Authorization: Bearer abc123DEF456ghi789";
+        String out = SecretRedactor.redact(in);
+
+        assertFalse(out.contains("abc123DEF456ghi789"), out);
+        assertTrue(out.contains(SecretRedactor.MASK), out);
+    }
+
+    @Test
+    void masksStandaloneJwt() {
+        String in = "cookie value eyJhbGciOiJIUzI1Ni19.eyJzdWIiOiIxMjM0NTY.SflKxwRJSMeKKF2QT4";
+        String out = SecretRedactor.redact(in);
+
+        assertFalse(out.contains("eyJhbGciOiJIUzI1Ni19"), out);
+        assertTrue(out.contains(SecretRedactor.MASK), out);
+    }
+
+    @Test
+    void leavesBenignTextUnchanged() {
+        String in = "[ThreadGroup] Login Flow\n  | num_threads = 100\n  | ramp_time = 30";
+        assertEquals(in, SecretRedactor.redact(in));
+    }
+
+    @Test
+    void handlesNullAndEmpty() {
+        assertNull(SecretRedactor.redact(null));
+        assertEquals("", SecretRedactor.redact(""));
+    }
+
+    @Test
+    void isEnabledByDefault() {
+        assertTrue(SecretRedactor.isEnabled());
+    }
+}


### PR DESCRIPTION
## Summary

Lets the agent **actually run JMeter tests and parse JTL results through MCP tools** rather than free text, by writing a **project-scoped MCP config** into the working (test-plan) directory before the CLI launches. Pairs the plugin with the [JMeter MCP server](https://github.com/QAInsights/jmeter-mcp-server).

> Note: stacks on #61 → #62 → #63 → #64. This branch contains all five commits; review the `feat(mcp): …` commit in isolation, or merge the stack in order.

## How it works

The terminal already launches each CLI with the test-plan directory as its working directory. This change writes the CLI's MCP config there, so it's automatically picked up and **never disturbs the user's global config**.

- For Kiro: `<test-plan-dir>/.kiro/settings/mcp.json` (Kiro's documented [workspace MCP location](https://kiro.dev/docs/cli/mcp/configuration/)).
- Schema: the standard `{"mcpServers": { ... }}` with `command` / `args` / `env` / `autoApprove` / `disabled`.

## Components (new `org.qainsights.jmeter.ai.mcp` package)

- **`McpServerConfig`** — one server entry with dependency-free JSON rendering.
- **`McpConfigProvider`** — builds servers from properties. The JMeter MCP server is wired as `uv --directory <dir> run jmeter_server.py` when `jmeter.ai.mcp.jmeter.dir` points at a local checkout; **default writes nothing** (safe no-op).
- **`McpConfigWriter`** — renders the document and writes it to the CLI's config path under the working dir.
- **Adapter contract** — `BaseCliAdapter.supportsMcp()` / `mcpConfigRelativePath()` (default off); `KiroCliAdapter` opts in with `.kiro/settings/mcp.json`.
- Wired into **both** launch paths: `ClaudeCodePanel` (GUI) and `HeadlessAiRunner` (CI).

## Configuration

```properties
jmeter.ai.mcp.enabled=true
jmeter.ai.mcp.jmeter.dir=/path/to/jmeter-mcp-server   # blank = disabled
jmeter.ai.mcp.jmeter.command=uv
jmeter.ai.mcp.jmeter.autoApprove=execute_jmeter_test,analyze_jtl
```

## Testing

`mvn clean test` → **BUILD SUCCESS**, 36 tests: `McpServerConfigTest` (3, JSON rendering + escaping), `McpConfigProviderTest` (3, property-driven server build / disabled / unset), `McpConfigWriterTest` (4, document render + writes `.kiro/settings/mcp.json` + null when unsupported/unconfigured), plus adapter MCP tests. Java 8 compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires MCP servers into the CLI working directory so the agent can run JMeter tests and parse JTLs via tools instead of free text. Also adds Kiro CLI support, a headless runner, and governance (secret redaction and audit) applied to all launches.

- **New Features**
  - Project-scoped MCP config is auto-written for supported CLIs; Kiro reads `./.kiro/settings/mcp.json`. Includes the JMeter MCP server when configured and launches it as `uv --directory <dir> run jmeter_server.py`.
  - Kiro CLI adapter (`kiro-cli`) with interactive and headless modes, robust binary detection, and a default read-only tool-trust policy.
  - Headless runner (`HeadlessAiRunner` + `run-ai-headless.sh` / `.bat`) that emits Markdown/JSON reports and returns CI-friendly exit codes.
  - Governance: masks secrets before writing `CLAUDE.md` / `AGENTS.md` / `KIRO.md`, and records an append-only audit line per launch with a SHA-256 of the shared context.

- **Migration**
  - To enable MCP: set `jmeter.ai.mcp.jmeter.dir` (path to the `jmeter-mcp-server` checkout); optional `jmeter.ai.mcp.jmeter.autoApprove`.
  - For headless: call the provided script and set `KIRO_API_KEY` for Kiro.
  - Optional: tune trust (`jmeter.ai.terminal.kiro.trust_tools` or `...trust_all_tools`) and audit/redaction properties.

<sup>Written for commit cfbd0bb2091d6069754cc71054f1221a84ab063c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/QAInsights/jmeter-ai/pull/65?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

