### PR TITLE
feat(agent): add OpenAI tool-calling support for agent mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 | 🧹 **Smart Refactoring** | Right-click in the JSR223 editor to refactor, format, or inject functions with AI. |
 | 🔍 **Context-Aware Commands** | `@this`, `@testplan`, `@optimize`, `@lint`, `@wrap`, `@code`, `@usage` — each tailored to your test plan. |
 | 🔔 **Audio Chime** | Optional sound notification when AI finishes responding. |
-| 🤖 **Agent Mode** | AI autonomously edits your test plan — add elements, set properties, run tests, correlate dynamic values — through 18 tools. **Claude only.** |
+| 🤖 **Agent Mode** | AI autonomously edits your test plan — add elements, set properties, run tests, correlate dynamic values — through 18 tools. **Claude & OpenAI.** |
 | 🔧 **Model Filtering** | Only chat-compatible models appear in the dropdown — no audio/TTS clutter. |
 | ⚙️ **Fully Configurable** | Customize prompts, temperature, tokens, history, timeouts, and more via JMeter properties. |
 
@@ -284,7 +284,7 @@ Type any of these directly in the chat box. All commands are context-aware and w
 
 Agent Mode lets the AI **autonomously edit your live JMeter test plan** through a tool-calling loop. Instead of just chatting about what you should do, the agent reads the tree, reasons about needed changes, calls tools to mutate elements, verifies the results, and iterates until the task is done — all inside the existing chat panel.
 
-> ⚠️ **Claude only.** Agent Mode currently works exclusively with **Anthropic Claude** models. OpenAI, Gemini, DeepSeek, and Ollama are not supported — they fall back to plain chat. Support for additional providers is planned.
+> ⚠️ **Claude & OpenAI only.** Agent Mode currently works with **Anthropic Claude** and **OpenAI** models. Gemini, DeepSeek, Ollama, Grok, and Bedrock are not supported — they fall back to plain chat. Support for additional providers is planned.
 
 <div align="center">
 
@@ -301,9 +301,13 @@ Agent Mode is **off by default**. To turn it on:
 jmeter.ai.agent.enabled=true
 ```
 
-Select a **Claude** model from the dropdown. Then just type your request naturally in the chat box — if Agent Mode is enabled and a Claude model is selected, the agent loop activates automatically.
+Select a **Claude** or **OpenAI** model from the dropdown. Then just type your request naturally in the chat box — if Agent Mode is enabled and a supported model is selected, the agent loop activates automatically.
 
-> If a non-Claude model is selected, the request is handled by the regular (non-agentic) chat path.
+> If a model from any other provider is selected, the request is handled by the regular (non-agentic) chat path.
+
+Both providers get the exact same tools, system prompt, safety gates and iteration limits — only the wire format differs (Anthropic `tool_use` blocks vs. OpenAI function `tool_calls`).
+
+> 💡 **OpenAI note**: temperature is left at the model default for agent runs, so reasoning models (`o1`, `o3`, `o4`, `gpt-5`) work without extra configuration. `jmeter.ai.agent.max.tokens` maps to `max_completion_tokens`. For **gpt-5.1 and later** (`gpt-5.6-terra`, `gpt-5.6-sol`, ...) the agent automatically sends `reasoning_effort=none`, because those models reject function tools on `/v1/chat/completions` while reasoning is on — so tool calling works out of the box.
 
 ### Agent Settings
 
@@ -386,7 +390,7 @@ Each tool call and result is streamed to the chat in real time, so you can follo
 
 ### Examples
 
-Try these in the chat box with Agent Mode enabled and a Claude model selected:
+Try these in the chat box with Agent Mode enabled and a Claude or OpenAI model selected:
 
 | Request | What the agent does |
 |---------|-------------------|

--- a/jmeter-ai-sample.properties
+++ b/jmeter-ai-sample.properties
@@ -1,7 +1,7 @@
 jmeter.ai.streaming.enabled=true
 ##### AGENT MODE SETTINGS #####
 # Agent Mode lets the AI autonomously edit your test plan through 18 tools.
-# Currently supports Claude models only (other providers fall back to plain chat).
+# Currently supports Claude and OpenAI models (other providers fall back to plain chat).
 # Enable agent mode (default: false)
 jmeter.ai.agent.enabled=false
 # Max tokens per agent response (default: 4096)

--- a/src/main/java/org/qainsights/jmeter/ai/agent/AgentChatModelFactory.java
+++ b/src/main/java/org/qainsights/jmeter/ai/agent/AgentChatModelFactory.java
@@ -1,0 +1,25 @@
+package org.qainsights.jmeter.ai.agent;
+
+import java.util.List;
+
+import org.qainsights.jmeter.ai.agent.loop.ChatModel;
+import org.qainsights.jmeter.ai.agent.tool.ToolSpec;
+
+/**
+ * Creates a fresh, provider-specific {@link ChatModel} for a single agent run.
+ * This is the one seam {@link JMeterAgent} needs to stay provider-neutral: each
+ * provider (Claude, OpenAI, ...) supplies a factory that knows how to wire its
+ * own SDK client, tool schema and seed messages.
+ */
+@FunctionalInterface
+public interface AgentChatModelFactory {
+
+    /**
+     * @param specs                   the tools to advertise to the model
+     * @param systemPrompt            the schema-grounded system prompt
+     * @param priorConversationTurns  normalized alternating user/assistant turns
+     *                                 (see {@link ConversationSeed#normalize}); may be empty
+     * @return a stateful chat model scoped to one run
+     */
+    ChatModel create(List<ToolSpec> specs, String systemPrompt, List<String> priorConversationTurns);
+}

--- a/src/main/java/org/qainsights/jmeter/ai/agent/ConversationSeed.java
+++ b/src/main/java/org/qainsights/jmeter/ai/agent/ConversationSeed.java
@@ -1,0 +1,40 @@
+package org.qainsights.jmeter.ai.agent;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Provider-neutral normalization of the chat panel's flat conversation history
+ * into the strict user/assistant/user/... shape every provider expects as seed
+ * history for an agent run. Each provider's {@code ChatModel} then maps the
+ * normalized list onto its own message types.
+ */
+public final class ConversationSeed {
+
+    private ConversationSeed() {
+    }
+
+    /**
+     * Drops a trailing unpaired turn (so the seed always ends on an assistant turn)
+     * and keeps only the most recent {@code maxTurnPairs} user/assistant pairs.
+     *
+     * @param priorConversationTurns earlier turns in user/assistant/user/... order; may be null
+     * @param maxTurnPairs           maximum number of pairs to retain
+     * @return an even-sized, alternating list starting with a user turn
+     */
+    public static List<String> normalize(List<String> priorConversationTurns, int maxTurnPairs) {
+        if (priorConversationTurns == null || priorConversationTurns.isEmpty() || maxTurnPairs < 1) {
+            return Collections.emptyList();
+        }
+        List<String> turns = new ArrayList<>(priorConversationTurns);
+        if (turns.size() % 2 != 0) {
+            turns.remove(turns.size() - 1);
+        }
+        int maxEntries = maxTurnPairs * 2;
+        if (turns.size() > maxEntries) {
+            turns = turns.subList(turns.size() - maxEntries, turns.size());
+        }
+        return Collections.unmodifiableList(new ArrayList<>(turns));
+    }
+}

--- a/src/main/java/org/qainsights/jmeter/ai/agent/JMeterAgent.java
+++ b/src/main/java/org/qainsights/jmeter/ai/agent/JMeterAgent.java
@@ -1,6 +1,5 @@
 package org.qainsights.jmeter.ai.agent;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -15,25 +14,32 @@ import org.qainsights.jmeter.ai.agent.claude.ClaudeToolAdapter;
 import org.qainsights.jmeter.ai.agent.jmeter.SwingToolConfirmationGate;
 import org.qainsights.jmeter.ai.agent.loop.AgentLoop;
 import org.qainsights.jmeter.ai.agent.loop.AssistantTurn;
+import org.qainsights.jmeter.ai.agent.loop.ChatModel;
+import org.qainsights.jmeter.ai.agent.openai.OpenAiChatModel;
+import org.qainsights.jmeter.ai.agent.openai.OpenAiToolAdapter;
 import org.qainsights.jmeter.ai.agent.schema.SchemaGrounding;
 import org.qainsights.jmeter.ai.agent.tool.AgentToolRegistry;
 import org.qainsights.jmeter.ai.agent.tool.ToolConfirmationGate;
 import org.qainsights.jmeter.ai.agent.tool.ToolExecutor;
 import org.qainsights.jmeter.ai.agent.tool.ToolRegistry;
+import org.qainsights.jmeter.ai.agent.tool.ToolSpec;
 import org.qainsights.jmeter.ai.agent.tool.handlers.ApplyCorrelationHandler;
 import org.qainsights.jmeter.ai.agent.tool.handlers.DeleteElementHandler;
 import org.qainsights.jmeter.ai.agent.tool.handlers.MoveElementHandler;
 import org.qainsights.jmeter.ai.agent.tool.handlers.OpenPlanHandler;
+import org.qainsights.jmeter.ai.service.AiService;
 import org.qainsights.jmeter.ai.service.ClaudeService;
+import org.qainsights.jmeter.ai.service.OpenAiService;
 import org.qainsights.jmeter.ai.utils.AiConfig;
 
 import com.anthropic.client.AnthropicClient;
-import com.anthropic.models.messages.MessageParam;
+import com.openai.client.OpenAIClient;
 
 /**
  * Façade that wires the tool registry, executor, schema-grounded system prompt
- * and a provider {@link ClaudeChatModel} into a runnable {@link AgentLoop}. This
- * is the single entry point the chat UI calls to run an agentic request.
+ * and a provider {@link ChatModel} (Claude or OpenAI, via
+ * {@link AgentChatModelFactory}) into a runnable {@link AgentLoop}. This is the
+ * single entry point the chat UI calls to run an agentic request.
  */
 public final class JMeterAgent {
 
@@ -53,9 +59,7 @@ public final class JMeterAgent {
     /** Ensures the undo-history nudge (see {@link #maybeWarnAboutUndoHistory}) fires once per session. */
     private static final AtomicBoolean UNDO_NUDGE_SHOWN = new AtomicBoolean(false);
 
-    private final ClaudeChatModel.MessageService service;
-    private final String model;
-    private final long maxTokens;
+    private final AgentChatModelFactory chatModelFactory;
     private final int maxIterations;
     private final ToolConfirmationGate confirmationGate;
 
@@ -70,11 +74,35 @@ public final class JMeterAgent {
      */
     public JMeterAgent(ClaudeChatModel.MessageService service, String model, long maxTokens, int maxIterations,
                        ToolConfirmationGate confirmationGate) {
-        this.service = service;
-        this.model = model;
-        this.maxTokens = maxTokens;
+        this(claudeFactory(service, model, maxTokens), maxIterations, confirmationGate);
+    }
+
+    /**
+     * Provider-neutral constructor: any {@link AgentChatModelFactory} (Claude, OpenAI, ...)
+     * can drive the same tool registry, system prompt and loop.
+     */
+    public JMeterAgent(AgentChatModelFactory chatModelFactory, int maxIterations,
+                       ToolConfirmationGate confirmationGate) {
+        if (chatModelFactory == null) {
+            throw new IllegalArgumentException("chatModelFactory must not be null");
+        }
+        this.chatModelFactory = chatModelFactory;
         this.maxIterations = maxIterations;
         this.confirmationGate = confirmationGate;
+    }
+
+    /** Builds a factory that wires the Anthropic {@link ClaudeChatModel} for each run. */
+    public static AgentChatModelFactory claudeFactory(ClaudeChatModel.MessageService service, String model,
+                                                      long maxTokens) {
+        return (specs, systemPrompt, priorTurns) -> new ClaudeChatModel(service, new ClaudeToolAdapter(),
+                specs, systemPrompt, model, maxTokens, ClaudeChatModel.toSeedHistory(priorTurns));
+    }
+
+    /** Builds a factory that wires the OpenAI {@link OpenAiChatModel} for each run. */
+    public static AgentChatModelFactory openAiFactory(OpenAiChatModel.CompletionService service, String model,
+                                                      long maxTokens) {
+        return (specs, systemPrompt, priorTurns) -> new OpenAiChatModel(service, new OpenAiToolAdapter(),
+                specs, systemPrompt, model, maxTokens, OpenAiChatModel.toSeedHistory(priorTurns));
     }
 
     /** True if the agent mode is enabled via {@code jmeter.ai.agent.enabled}. */
@@ -95,6 +123,41 @@ public final class JMeterAgent {
         boolean confirmDestructive = Boolean.parseBoolean(AiConfig.getProperty(CONFIRM_DESTRUCTIVE_KEY, "true"));
         ToolConfirmationGate gate = confirmDestructive ? new SwingToolConfirmationGate() : null;
         return new JMeterAgent(service, claude.getCurrentModel(), maxTokens, maxIterations, gate);
+    }
+
+    /**
+     * Wires an agent against an existing {@link OpenAiService}'s client and model, using the
+     * same tool registry, system prompt, limits and destructive-tool confirmation as
+     * {@link #forClaude(ClaudeService)}.
+     */
+    public static JMeterAgent forOpenAi(OpenAiService openAi) {
+        long maxTokens = parseLong(AiConfig.getProperty(MAX_TOKENS_KEY, "4096"), 4096L);
+        int maxIterations = (int) parseLong(AiConfig.getProperty(MAX_ITERATIONS_KEY, "8"), 8L);
+        OpenAIClient client = openAi.getClient();
+        OpenAiChatModel.CompletionService service = params -> client.chat().completions().create(params);
+        return new JMeterAgent(openAiFactory(service, openAi.getCurrentModel(), maxTokens), maxIterations,
+                destructiveGate());
+    }
+
+    /**
+     * Wires an agent for whichever provider backs {@code service}, or returns {@code null}
+     * if that provider has no tool-calling adapter yet (the caller then falls back to the
+     * plain, non-agentic chat path).
+     */
+    public static JMeterAgent forService(AiService service) {
+        if (service instanceof ClaudeService) {
+            return forClaude((ClaudeService) service);
+        }
+        if (service instanceof OpenAiService) {
+            return forOpenAi((OpenAiService) service);
+        }
+        return null;
+    }
+
+    /** The confirmation gate for destructive tools, or {@code null} when disabled by config. */
+    private static ToolConfirmationGate destructiveGate() {
+        boolean confirmDestructive = Boolean.parseBoolean(AiConfig.getProperty(CONFIRM_DESTRUCTIVE_KEY, "true"));
+        return confirmDestructive ? new SwingToolConfirmationGate() : null;
     }
 
     /**
@@ -139,35 +202,10 @@ public final class JMeterAgent {
         ToolRegistry registry = AgentToolRegistry.createDefault();
         ToolExecutor executor = new ToolExecutor(registry, DESTRUCTIVE_TOOLS, confirmationGate);
         String systemPrompt = AgentSystemPrompt.build(new SchemaGrounding());
-        List<MessageParam> seedHistory = toSeedHistory(priorConversationTurns);
-        ClaudeChatModel chat = new ClaudeChatModel(service, new ClaudeToolAdapter(),
-                registry.getSpecs(), systemPrompt, model, maxTokens, seedHistory);
+        List<String> seedTurns = ConversationSeed.normalize(priorConversationTurns, MAX_HISTORY_TURN_PAIRS);
+        List<ToolSpec> specs = registry.getSpecs();
+        ChatModel chat = chatModelFactory.create(specs, systemPrompt, seedTurns);
         return new AgentLoop(chat, executor, maxIterations).run(userMessage, progress, onToolCallStarted);
-    }
-
-    /**
-     * Converts flat alternating user/assistant strings into seed {@link MessageParam}s,
-     * dropping a trailing unpaired turn (so the seed always ends on an assistant turn) and
-     * capping to the most recent {@link #MAX_HISTORY_TURN_PAIRS} pairs.
-     */
-    private static List<MessageParam> toSeedHistory(List<String> priorConversationTurns) {
-        if (priorConversationTurns == null || priorConversationTurns.isEmpty()) {
-            return Collections.emptyList();
-        }
-        List<String> turns = new ArrayList<>(priorConversationTurns);
-        if (turns.size() % 2 != 0) {
-            turns.remove(turns.size() - 1);
-        }
-        int maxEntries = MAX_HISTORY_TURN_PAIRS * 2;
-        if (turns.size() > maxEntries) {
-            turns = turns.subList(turns.size() - maxEntries, turns.size());
-        }
-        List<MessageParam> history = new ArrayList<>();
-        for (int i = 0; i < turns.size(); i++) {
-            MessageParam.Role role = (i % 2 == 0) ? MessageParam.Role.USER : MessageParam.Role.ASSISTANT;
-            history.add(MessageParam.builder().role(role).content(turns.get(i)).build());
-        }
-        return history;
     }
 
     private static long parseLong(String value, long fallback) {

--- a/src/main/java/org/qainsights/jmeter/ai/agent/claude/ClaudeChatModel.java
+++ b/src/main/java/org/qainsights/jmeter/ai/agent/claude/ClaudeChatModel.java
@@ -58,6 +58,22 @@ public final class ClaudeChatModel implements ChatModel {
         this.history = new ArrayList<>(seedHistory);
     }
 
+    /**
+     * Converts flat alternating user/assistant strings (already normalized by
+     * {@code ConversationSeed}) into Anthropic seed messages.
+     */
+    public static List<MessageParam> toSeedHistory(List<String> alternatingTurns) {
+        List<MessageParam> seed = new ArrayList<>();
+        if (alternatingTurns == null) {
+            return seed;
+        }
+        for (int i = 0; i < alternatingTurns.size(); i++) {
+            MessageParam.Role role = (i % 2 == 0) ? MessageParam.Role.USER : MessageParam.Role.ASSISTANT;
+            seed.add(MessageParam.builder().role(role).content(alternatingTurns.get(i)).build());
+        }
+        return seed;
+    }
+
     @Override
     public AssistantTurn start(String userMessage) {
         history.add(MessageParam.builder()

--- a/src/main/java/org/qainsights/jmeter/ai/agent/claude/ClaudeToolAdapter.java
+++ b/src/main/java/org/qainsights/jmeter/ai/agent/claude/ClaudeToolAdapter.java
@@ -7,8 +7,7 @@ import java.util.Map;
 
 import org.qainsights.jmeter.ai.agent.loop.AssistantTurn;
 import org.qainsights.jmeter.ai.agent.loop.ToolOutcome;
-import org.qainsights.jmeter.ai.agent.tool.ParamType;
-import org.qainsights.jmeter.ai.agent.tool.ToolParameter;
+import org.qainsights.jmeter.ai.agent.tool.JsonSchemaMapper;
 import org.qainsights.jmeter.ai.agent.tool.ToolSpec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,31 +31,13 @@ public final class ClaudeToolAdapter {
     /** Converts a provider-neutral spec into an Anthropic tool definition. */
     public Tool toAnthropicTool(ToolSpec spec) {
         Tool.InputSchema.Properties.Builder properties = Tool.InputSchema.Properties.builder();
-        List<String> required = new ArrayList<>();
-
-        for (ToolParameter param : spec.getParameters()) {
-            Map<String, Object> propSchema = new LinkedHashMap<>();
-            propSchema.put("type", jsonType(param.getType()));
-            if (param.getType() == ParamType.STRING_ARRAY) {
-                propSchema.put("items", Map.of("type", "string"));
-            } else if (param.getType() == ParamType.OBJECT_ARRAY) {
-                propSchema.put("items", Map.of("type", "object"));
-            }
-            if (param.getDescription() != null && !param.getDescription().isEmpty()) {
-                propSchema.put("description", param.getDescription());
-            }
-            if (!param.getEnumValues().isEmpty()) {
-                propSchema.put("enum", param.getEnumValues());
-            }
-            properties.putAdditionalProperty(param.getName(), JsonValue.from(propSchema));
-            if (param.isRequired()) {
-                required.add(param.getName());
-            }
+        for (Map.Entry<String, Object> property : JsonSchemaMapper.properties(spec).entrySet()) {
+            properties.putAdditionalProperty(property.getKey(), JsonValue.from(property.getValue()));
         }
 
         Tool.InputSchema schema = Tool.InputSchema.builder()
                 .properties(properties.build())
-                .required(required)
+                .required(JsonSchemaMapper.required(spec))
                 .build();
 
         return Tool.builder()
@@ -99,25 +80,6 @@ public final class ClaudeToolAdapter {
         } catch (RuntimeException e) {
             log.warn("Could not parse tool_use input as a map: {}", input, e);
             return new LinkedHashMap<>();
-        }
-    }
-
-    private static String jsonType(ParamType type) {
-        switch (type) {
-            case INTEGER:
-                return "integer";
-            case NUMBER:
-                return "number";
-            case BOOLEAN:
-                return "boolean";
-            case OBJECT:
-                return "object";
-            case STRING_ARRAY:
-            case OBJECT_ARRAY:
-                return "array";
-            case STRING:
-            default:
-                return "string";
         }
     }
 }

--- a/src/main/java/org/qainsights/jmeter/ai/agent/openai/OpenAiChatModel.java
+++ b/src/main/java/org/qainsights/jmeter/ai/agent/openai/OpenAiChatModel.java
@@ -1,0 +1,136 @@
+package org.qainsights.jmeter.ai.agent.openai;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.qainsights.jmeter.ai.agent.loop.AssistantTurn;
+import org.qainsights.jmeter.ai.agent.loop.ChatModel;
+import org.qainsights.jmeter.ai.agent.loop.ToolOutcome;
+import org.qainsights.jmeter.ai.agent.tool.ToolSpec;
+
+import com.openai.models.ReasoningEffort;
+import com.openai.models.chat.completions.ChatCompletion;
+import com.openai.models.chat.completions.ChatCompletionAssistantMessageParam;
+import com.openai.models.chat.completions.ChatCompletionCreateParams;
+import com.openai.models.chat.completions.ChatCompletionMessage;
+import com.openai.models.chat.completions.ChatCompletionMessageParam;
+import com.openai.models.chat.completions.ChatCompletionUserMessageParam;
+
+/**
+ * OpenAI-backed {@link ChatModel}. Stateful for a single agent run: it owns the
+ * growing message history and re-sends it (with the system prompt and function
+ * tool definitions) on each turn. The assistant's reply is echoed back into the
+ * history via {@link ChatCompletionMessage#toParam()} (which preserves its tool
+ * calls), and each tool outcome is appended as a {@code tool} role message.
+ * Create a new instance per run.
+ * <p>
+ * Temperature is deliberately not set: several OpenAI models (o1/o3/o4/gpt-5)
+ * reject any value other than the default. {@code reasoning_effort} is set only
+ * where {@link OpenAiReasoningPolicy} says tool calling requires it.
+ */
+public final class OpenAiChatModel implements ChatModel {
+
+    /** Seam over {@code client.chat().completions().create(params)} for testability. */
+    @FunctionalInterface
+    public interface CompletionService {
+        ChatCompletion create(ChatCompletionCreateParams params);
+    }
+
+    private final CompletionService service;
+    private final OpenAiToolAdapter adapter;
+    private final List<ToolSpec> specs;
+    private final String systemPrompt;
+    private final String model;
+    private final long maxTokens;
+    private final Optional<ReasoningEffort> reasoningEffort;
+    private final List<ChatCompletionMessageParam> history;
+
+    public OpenAiChatModel(CompletionService service, OpenAiToolAdapter adapter, List<ToolSpec> specs,
+                           String systemPrompt, String model, long maxTokens) {
+        this(service, adapter, specs, systemPrompt, model, maxTokens, Collections.emptyList());
+    }
+
+    /**
+     * @param seedHistory prior conversation turns (e.g. from an earlier chat message) to
+     *                     prepend before the new user message, giving the model multi-turn
+     *                     memory across separate agent runs.
+     */
+    public OpenAiChatModel(CompletionService service, OpenAiToolAdapter adapter, List<ToolSpec> specs,
+                           String systemPrompt, String model, long maxTokens,
+                           List<ChatCompletionMessageParam> seedHistory) {
+        this.service = service;
+        this.adapter = adapter;
+        this.specs = new ArrayList<>(specs);
+        this.systemPrompt = systemPrompt;
+        this.model = model;
+        this.maxTokens = maxTokens;
+        this.reasoningEffort = OpenAiReasoningPolicy.forToolCalling(model);
+        this.history = new ArrayList<>(seedHistory);
+    }
+
+    /**
+     * Converts flat alternating user/assistant strings (already normalized by
+     * {@code ConversationSeed}) into OpenAI seed messages.
+     */
+    public static List<ChatCompletionMessageParam> toSeedHistory(List<String> alternatingTurns) {
+        List<ChatCompletionMessageParam> seed = new ArrayList<>();
+        if (alternatingTurns == null) {
+            return seed;
+        }
+        for (int i = 0; i < alternatingTurns.size(); i++) {
+            String turn = alternatingTurns.get(i);
+            if (i % 2 == 0) {
+                seed.add(userMessage(turn));
+            } else {
+                seed.add(ChatCompletionMessageParam.ofAssistant(
+                        ChatCompletionAssistantMessageParam.builder().content(turn).build()));
+            }
+        }
+        return seed;
+    }
+
+    @Override
+    public AssistantTurn start(String userMessage) {
+        history.add(userMessage(userMessage));
+        return send();
+    }
+
+    @Override
+    public AssistantTurn next(List<ToolOutcome> toolOutcomes) {
+        for (ToolOutcome outcome : toolOutcomes) {
+            history.add(ChatCompletionMessageParam.ofTool(adapter.toToolMessage(outcome)));
+        }
+        return send();
+    }
+
+    private AssistantTurn send() {
+        ChatCompletionCreateParams.Builder params = ChatCompletionCreateParams.builder()
+                .model(model)
+                .maxCompletionTokens(maxTokens)
+                .addSystemMessage(systemPrompt);
+        if (reasoningEffort.isPresent()) {
+            params.reasoningEffort(reasoningEffort.get());
+        }
+        for (ChatCompletionMessageParam message : history) {
+            params.addMessage(message);
+        }
+        for (ToolSpec spec : specs) {
+            params.addTool(adapter.toOpenAiTool(spec));
+        }
+
+        ChatCompletion completion = service.create(params.build());
+        if (completion.choices().isEmpty()) {
+            throw new IllegalStateException("OpenAI returned no choices for the agent request");
+        }
+        ChatCompletionMessage message = completion.choices().get(0).message();
+        history.add(ChatCompletionMessageParam.ofAssistant(message.toParam()));
+        return adapter.toAssistantTurn(message);
+    }
+
+    private static ChatCompletionMessageParam userMessage(String text) {
+        return ChatCompletionMessageParam.ofUser(
+                ChatCompletionUserMessageParam.builder().content(text).build());
+    }
+}

--- a/src/main/java/org/qainsights/jmeter/ai/agent/openai/OpenAiReasoningPolicy.java
+++ b/src/main/java/org/qainsights/jmeter/ai/agent/openai/OpenAiReasoningPolicy.java
@@ -1,0 +1,45 @@
+package org.qainsights.jmeter.ai.agent.openai;
+
+import java.util.Locale;
+import java.util.Optional;
+
+import com.openai.models.ReasoningEffort;
+
+/**
+ * Decides the {@code reasoning_effort} an agent (tool-calling) request must send
+ * for a given OpenAI model.
+ * <p>
+ * The gpt-5.1-and-later reasoning models reject function tools on
+ * {@code /v1/chat/completions} unless reasoning is explicitly switched off:
+ * <blockquote>
+ * 400: Function tools with reasoning_effort are not supported for gpt-5.6-terra in
+ * /v1/chat/completions. To use function tools, use /v1/responses or set
+ * reasoning_effort to 'none'.
+ * </blockquote>
+ * Those models are identified by their dotted minor version ({@code gpt-5.1},
+ * {@code gpt-5.6-terra}, {@code gpt-5.6-sol}, ...); {@code none} is only a valid
+ * effort from gpt-5.1 onwards, so the original {@code gpt-5}/{@code gpt-5-mini}
+ * line and the o-series are left untouched (they accept function tools as-is).
+ */
+public final class OpenAiReasoningPolicy {
+
+    private OpenAiReasoningPolicy() {
+    }
+
+    /**
+     * @param model the bare OpenAI model id (no {@code openai:} prefix)
+     * @return the effort to send with a tool-calling request, or empty to leave the
+     *         parameter off entirely (the model's default applies)
+     */
+    public static Optional<ReasoningEffort> forToolCalling(String model) {
+        return requiresDisabledReasoning(model) ? Optional.of(ReasoningEffort.NONE) : Optional.empty();
+    }
+
+    /** True for the gpt-5.1+ models that refuse function tools while reasoning. */
+    public static boolean requiresDisabledReasoning(String model) {
+        if (model == null) {
+            return false;
+        }
+        return model.trim().toLowerCase(Locale.ROOT).startsWith("gpt-5.");
+    }
+}

--- a/src/main/java/org/qainsights/jmeter/ai/agent/openai/OpenAiToolAdapter.java
+++ b/src/main/java/org/qainsights/jmeter/ai/agent/openai/OpenAiToolAdapter.java
@@ -1,0 +1,108 @@
+package org.qainsights.jmeter.ai.agent.openai;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.qainsights.jmeter.ai.agent.loop.AssistantTurn;
+import org.qainsights.jmeter.ai.agent.loop.ToolOutcome;
+import org.qainsights.jmeter.ai.agent.tool.JsonSchemaMapper;
+import org.qainsights.jmeter.ai.agent.tool.ToolSpec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.openai.core.JsonValue;
+import com.openai.models.FunctionDefinition;
+import com.openai.models.FunctionParameters;
+import com.openai.models.chat.completions.ChatCompletionFunctionTool;
+import com.openai.models.chat.completions.ChatCompletionMessage;
+import com.openai.models.chat.completions.ChatCompletionMessageFunctionToolCall;
+import com.openai.models.chat.completions.ChatCompletionMessageToolCall;
+import com.openai.models.chat.completions.ChatCompletionToolMessageParam;
+
+/**
+ * Translates between our provider-neutral tool model and the OpenAI
+ * (openai-java) chat-completions API: {@link ToolSpec} &rarr;
+ * {@link ChatCompletionFunctionTool} with a JSON function schema, an assistant
+ * {@link ChatCompletionMessage} &rarr; {@link AssistantTurn}, and a
+ * {@link ToolOutcome} &rarr; {@link ChatCompletionToolMessageParam}.
+ * <p>
+ * The OpenAI counterpart of {@code ClaudeToolAdapter}; both build their schemas
+ * from the same {@link JsonSchemaMapper} so tools look identical to every provider.
+ */
+public final class OpenAiToolAdapter {
+
+    private static final Logger log = LoggerFactory.getLogger(OpenAiToolAdapter.class);
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<Map<String, Object>>() {
+    };
+
+    /** Converts a provider-neutral spec into an OpenAI function-tool definition. */
+    public ChatCompletionFunctionTool toOpenAiTool(ToolSpec spec) {
+        FunctionParameters parameters = FunctionParameters.builder()
+                .putAdditionalProperty("type", JsonValue.from("object"))
+                .putAdditionalProperty("properties", JsonValue.from(JsonSchemaMapper.properties(spec)))
+                .putAdditionalProperty("required", JsonValue.from(JsonSchemaMapper.required(spec)))
+                .build();
+
+        FunctionDefinition function = FunctionDefinition.builder()
+                .name(spec.getName())
+                .description(spec.getDescription())
+                .parameters(parameters)
+                .build();
+
+        return ChatCompletionFunctionTool.builder().function(function).build();
+    }
+
+    /**
+     * Flattens an assistant message into a neutral turn. Custom (non-function)
+     * tool calls are ignored - the agent only ever registers function tools.
+     */
+    public AssistantTurn toAssistantTurn(ChatCompletionMessage message) {
+        String text = message.content().orElse("");
+        List<AssistantTurn.ToolCall> calls = new ArrayList<>();
+        for (ChatCompletionMessageToolCall toolCall : message.toolCalls().orElse(Collections.emptyList())) {
+            if (!toolCall.isFunction()) {
+                log.warn("Ignoring non-function tool call from OpenAI: {}", toolCall);
+                continue;
+            }
+            ChatCompletionMessageFunctionToolCall function = toolCall.asFunction();
+            calls.add(new AssistantTurn.ToolCall(function.id(), function.function().name(),
+                    toArguments(function.function().arguments())));
+        }
+        return new AssistantTurn(text, calls);
+    }
+
+    /**
+     * Builds the {@code tool} role message that carries a tool call's outcome back
+     * to the model. OpenAI has no per-result error flag (unlike Anthropic's
+     * {@code is_error}), so failures are conveyed by the {@code ERROR [...]} prefix
+     * {@link ToolOutcome#from} already puts in the content.
+     */
+    public ChatCompletionToolMessageParam toToolMessage(ToolOutcome outcome) {
+        return ChatCompletionToolMessageParam.builder()
+                .toolCallId(outcome.getToolCallId())
+                .content(outcome.getContent())
+                .build();
+    }
+
+    /** Parses a function call's JSON argument string into a map, tolerating junk. */
+    private Map<String, Object> toArguments(String arguments) {
+        if (arguments == null || arguments.trim().isEmpty()) {
+            return new LinkedHashMap<>();
+        }
+        try {
+            Map<String, Object> parsed = JSON.readValue(arguments, MAP_TYPE);
+            return parsed == null ? new LinkedHashMap<>() : parsed;
+        } catch (Exception e) {
+            log.warn("Could not parse OpenAI tool call arguments as JSON: {}", arguments, e);
+            return new LinkedHashMap<>();
+        }
+    }
+}

--- a/src/main/java/org/qainsights/jmeter/ai/agent/tool/JsonSchemaMapper.java
+++ b/src/main/java/org/qainsights/jmeter/ai/agent/tool/JsonSchemaMapper.java
@@ -1,0 +1,80 @@
+package org.qainsights.jmeter.ai.agent.tool;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Provider-neutral translation of a {@link ToolSpec}'s parameters into plain
+ * JSON-Schema fragments. Both the Anthropic and OpenAI tool adapters build their
+ * SDK-specific schema objects from these maps, so a tool is advertised
+ * identically to every provider.
+ */
+public final class JsonSchemaMapper {
+
+    private JsonSchemaMapper() {
+    }
+
+    /**
+     * Builds the {@code properties} object of a tool's input schema, preserving
+     * the spec's parameter order.
+     */
+    public static Map<String, Object> properties(ToolSpec spec) {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        for (ToolParameter param : spec.getParameters()) {
+            properties.put(param.getName(), propertySchema(param));
+        }
+        return properties;
+    }
+
+    /** Builds the JSON-Schema fragment describing a single parameter. */
+    public static Map<String, Object> propertySchema(ToolParameter param) {
+        Map<String, Object> schema = new LinkedHashMap<>();
+        schema.put("type", jsonType(param.getType()));
+        if (param.getType() == ParamType.STRING_ARRAY) {
+            schema.put("items", Collections.singletonMap("type", "string"));
+        } else if (param.getType() == ParamType.OBJECT_ARRAY) {
+            schema.put("items", Collections.singletonMap("type", "object"));
+        }
+        if (param.getDescription() != null && !param.getDescription().isEmpty()) {
+            schema.put("description", param.getDescription());
+        }
+        if (!param.getEnumValues().isEmpty()) {
+            schema.put("enum", param.getEnumValues());
+        }
+        return schema;
+    }
+
+    /** Names of the spec's required parameters, in declaration order. */
+    public static List<String> required(ToolSpec spec) {
+        List<String> required = new ArrayList<>();
+        for (ToolParameter param : spec.getParameters()) {
+            if (param.isRequired()) {
+                required.add(param.getName());
+            }
+        }
+        return required;
+    }
+
+    /** Maps a neutral {@link ParamType} onto its JSON-Schema {@code type} keyword. */
+    public static String jsonType(ParamType type) {
+        switch (type) {
+            case INTEGER:
+                return "integer";
+            case NUMBER:
+                return "number";
+            case BOOLEAN:
+                return "boolean";
+            case OBJECT:
+                return "object";
+            case STRING_ARRAY:
+            case OBJECT_ARRAY:
+                return "array";
+            case STRING:
+            default:
+                return "string";
+        }
+    }
+}

--- a/src/main/java/org/qainsights/jmeter/ai/gui/CommandDispatcher.java
+++ b/src/main/java/org/qainsights/jmeter/ai/gui/CommandDispatcher.java
@@ -6,7 +6,6 @@ import org.qainsights.jmeter.ai.agent.loop.AssistantTurn;
 import org.qainsights.jmeter.ai.lint.LintCommandHandler;
 import org.qainsights.jmeter.ai.optimizer.OptimizeRequestHandler;
 import org.qainsights.jmeter.ai.service.AiService;
-import org.qainsights.jmeter.ai.service.ClaudeService;
 import org.qainsights.jmeter.ai.usage.UsageCommandHandler;
 import org.qainsights.jmeter.ai.utils.JMeterElementRequestHandler;
 import org.qainsights.jmeter.ai.utils.AiConfig;
@@ -80,8 +79,8 @@ public class CommandDispatcher {
                 break;
         }
 
-        // Tier 2: agentic tool-calling loop (feature-flagged; Claude only for the MVP).
-        if (JMeterAgent.isEnabled() && isClaudeModel(cb.getSelectedModel())) {
+        // Tier 2: agentic tool-calling loop (feature-flagged; Claude and OpenAI).
+        if (JMeterAgent.isEnabled() && isAgentCapableModel(cb.getSelectedModel())) {
             handleAgentCommand(message);
             return;
         }
@@ -421,10 +420,11 @@ public class CommandDispatcher {
             protected String doInBackground() {
                 try {
                     AiService service = cb.resolveAiService(cb.getSelectedModel());
-                    if (!(service instanceof ClaudeService)) {
-                        return finish("Agent mode currently supports Claude models only. Select a Claude model and retry.");
+                    JMeterAgent agent = JMeterAgent.forService(service);
+                    if (agent == null) {
+                        return finish("Agent mode currently supports Claude and OpenAI models only. "
+                                + "Select one of those and retry.");
                     }
-                    JMeterAgent agent = JMeterAgent.forClaude((ClaudeService) service);
                     AgentLoop.AgentResult result;
                     try {
                         result = agent.run(message, priorTurns,
@@ -492,7 +492,16 @@ public class CommandDispatcher {
         }.execute();
     }
 
-    /** True when the selected model routes to Claude (the only agent provider in the MVP). */
+    /**
+     * True when the selected model routes to a provider with a tool-calling adapter,
+     * i.e. Anthropic Claude or OpenAI. Every other provider falls back to plain chat.
+     */
+    static boolean isAgentCapableModel(String selectedModel) {
+        return isClaudeModel(selectedModel)
+                || (selectedModel != null && selectedModel.startsWith("openai:"));
+    }
+
+    /** True when the selected model routes to Claude (non-prefixed model ids). */
     static boolean isClaudeModel(String selectedModel) {
         if (selectedModel == null || selectedModel.isEmpty()) {
             return true;

--- a/src/test/java/org/qainsights/jmeter/ai/agent/ConversationSeedTest.java
+++ b/src/test/java/org/qainsights/jmeter/ai/agent/ConversationSeedTest.java
@@ -1,0 +1,72 @@
+package org.qainsights.jmeter.ai.agent;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Unit tests for {@link ConversationSeed#normalize(List, int)}. */
+class ConversationSeedTest {
+
+    @Test
+    void normalize_nullOrEmpty_returnsEmptyList() {
+        assertTrue(ConversationSeed.normalize(null, 10).isEmpty());
+        assertTrue(ConversationSeed.normalize(Collections.<String>emptyList(), 10).isEmpty());
+    }
+
+    @Test
+    void normalize_evenTurns_keepsThemAsIs() {
+        List<String> turns = Arrays.asList("ask", "answer");
+        assertEquals(turns, ConversationSeed.normalize(turns, 10));
+    }
+
+    @Test
+    void normalize_oddTurns_dropsTheTrailingUnpairedTurn() {
+        List<String> turns = Arrays.asList("ask", "answer", "dangling ask");
+        assertEquals(Arrays.asList("ask", "answer"), ConversationSeed.normalize(turns, 10));
+    }
+
+    @Test
+    void normalize_singleTurn_dropsIt() {
+        assertTrue(ConversationSeed.normalize(Collections.singletonList("ask"), 10).isEmpty());
+    }
+
+    @Test
+    void normalize_moreThanMaxPairs_keepsTheMostRecentOnes() {
+        List<String> turns = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            turns.add("ask " + i);
+            turns.add("answer " + i);
+        }
+
+        List<String> normalized = ConversationSeed.normalize(turns, 2);
+
+        assertEquals(Arrays.asList("ask 3", "answer 3", "ask 4", "answer 4"), normalized);
+    }
+
+    @Test
+    void normalize_zeroOrNegativeMaxPairs_returnsEmptyList() {
+        List<String> turns = Arrays.asList("ask", "answer");
+        assertTrue(ConversationSeed.normalize(turns, 0).isEmpty());
+        assertTrue(ConversationSeed.normalize(turns, -1).isEmpty());
+    }
+
+    @Test
+    void normalize_doesNotMutateTheCallersList() {
+        List<String> turns = new ArrayList<>(Arrays.asList("ask", "answer", "dangling"));
+
+        ConversationSeed.normalize(turns, 10);
+
+        assertEquals(3, turns.size());
+    }
+
+    @Test
+    void normalize_returnsAnUnmodifiableList() {
+        List<String> normalized = ConversationSeed.normalize(Arrays.asList("ask", "answer"), 10);
+        assertThrows(UnsupportedOperationException.class, () -> normalized.add("nope"));
+    }
+}

--- a/src/test/java/org/qainsights/jmeter/ai/agent/JMeterAgentOpenAiTest.java
+++ b/src/test/java/org/qainsights/jmeter/ai/agent/JMeterAgentOpenAiTest.java
@@ -1,0 +1,188 @@
+package org.qainsights.jmeter.ai.agent;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.qainsights.jmeter.ai.agent.loop.AgentLoop;
+import org.qainsights.jmeter.ai.agent.openai.OpenAiChatModel;
+import org.qainsights.jmeter.ai.agent.tool.ToolConfirmationGate;
+
+import com.openai.core.JsonValue;
+import com.openai.models.chat.completions.ChatCompletion;
+import com.openai.models.chat.completions.ChatCompletionCreateParams;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Mirror of {@link JMeterAgentTest} for the OpenAI provider: the same agent
+ * façade, tool registry and loop, driven by a fake completion service instead of
+ * the Anthropic one - proving the tools are provider-agnostic.
+ */
+class JMeterAgentOpenAiTest {
+
+    @BeforeEach
+    void resetUndoNudge() {
+        JMeterAgent.resetUndoNudgeForTests();
+    }
+
+    private static ChatCompletion completion(Map<String, Object> message) {
+        Map<String, Object> choice = new LinkedHashMap<>();
+        choice.put("index", 0);
+        choice.put("finish_reason", "stop");
+        choice.put("message", message);
+
+        Map<String, Object> json = new LinkedHashMap<>();
+        json.put("id", "chatcmpl_1");
+        json.put("object", "chat.completion");
+        json.put("created", 0);
+        json.put("model", "gpt-4o");
+        json.put("choices", Collections.singletonList(choice));
+        return JsonValue.from(json).convert(ChatCompletion.class);
+    }
+
+    private static ChatCompletion textCompletion(String text) {
+        Map<String, Object> message = new LinkedHashMap<>();
+        message.put("role", "assistant");
+        message.put("content", text);
+        return completion(message);
+    }
+
+    private static ChatCompletion toolCompletion(String id, String name, String arguments) {
+        Map<String, Object> function = new LinkedHashMap<>();
+        function.put("name", name);
+        function.put("arguments", arguments);
+        Map<String, Object> call = new LinkedHashMap<>();
+        call.put("id", id);
+        call.put("type", "function");
+        call.put("function", function);
+
+        Map<String, Object> message = new LinkedHashMap<>();
+        message.put("role", "assistant");
+        message.put("content", null);
+        message.put("tool_calls", Collections.singletonList(call));
+        return completion(message);
+    }
+
+    private static JMeterAgent agent(OpenAiChatModel.CompletionService service, ToolConfirmationGate gate) {
+        return new JMeterAgent(JMeterAgent.openAiFactory(service, "gpt-4o", 1024), 5, gate);
+    }
+
+    @Test
+    void run_completesWithFinalTextWhenNoToolsRequested() {
+        OpenAiChatModel.CompletionService service = params -> textCompletion("I can help with that.");
+
+        AgentLoop.AgentResult result = agent(service, null).run("hello", null);
+
+        assertTrue(result.isCompleted());
+        assertEquals("I can help with that.", result.getFinalText());
+        assertEquals(1, result.getIterations());
+    }
+
+    @Test
+    void run_advertisesTheFullToolRegistryToOpenAi() {
+        List<ChatCompletionCreateParams> captured = new ArrayList<>();
+        OpenAiChatModel.CompletionService service = params -> {
+            captured.add(params);
+            return textCompletion("ok");
+        };
+
+        agent(service, null).run("hello", null);
+
+        List<String> toolNames = new ArrayList<>();
+        for (com.openai.models.chat.completions.ChatCompletionTool tool
+                : captured.get(0).tools().orElse(Collections.emptyList())) {
+            toolNames.add(tool.asFunction().function().name());
+        }
+        assertTrue(toolNames.contains("get_tree_state"), "expected read tools, got " + toolNames);
+        assertTrue(toolNames.contains("add_element"), "expected write tools, got " + toolNames);
+        assertTrue(toolNames.contains("delete_element"), "expected destructive tools, got " + toolNames);
+    }
+
+    @Test
+    void run_withPriorConversation_seedsHistoryBeforeTheNewMessage() {
+        List<ChatCompletionCreateParams> captured = new ArrayList<>();
+        OpenAiChatModel.CompletionService service = params -> {
+            captured.add(params);
+            return textCompletion("Sure, added it.");
+        };
+
+        List<String> prior = Arrays.asList("add a thread group", "Added a Thread Group.");
+        AgentLoop.AgentResult result = agent(service, null).run("now add an http sampler", prior, null);
+
+        assertTrue(result.isCompleted());
+        // system + seed (2) + the new user message (1) = 4.
+        assertEquals(4, captured.get(0).messages().size());
+    }
+
+    @Test
+    void run_withOddPriorConversation_dropsTrailingUnpairedTurn() {
+        List<ChatCompletionCreateParams> captured = new ArrayList<>();
+        OpenAiChatModel.CompletionService service = params -> {
+            captured.add(params);
+            return textCompletion("ok");
+        };
+
+        agent(service, null).run("now add an http sampler",
+                Collections.singletonList("add a thread group"), null);
+
+        // system + the new user message only.
+        assertEquals(2, captured.get(0).messages().size());
+    }
+
+    @Test
+    void run_withNullPriorConversation_behavesLikeNoHistory() {
+        List<ChatCompletionCreateParams> captured = new ArrayList<>();
+        OpenAiChatModel.CompletionService service = params -> {
+            captured.add(params);
+            return textCompletion("ok");
+        };
+
+        agent(service, null).run("hello", null, null);
+
+        assertEquals(2, captured.get(0).messages().size());
+    }
+
+    @Test
+    void run_declinedDestructiveTool_neverReachesTheHandler() {
+        Deque<ChatCompletion> responses = new ArrayDeque<>();
+        responses.add(toolCompletion("call_1", "delete_element",
+                "{\"element_id\":\"Test Plan/Thread Group\"}"));
+        responses.add(textCompletion("Okay, I will not delete it."));
+        OpenAiChatModel.CompletionService service = params -> responses.removeFirst();
+
+        List<String> progressLines = new ArrayList<>();
+        AgentLoop.AgentResult result = agent(service, (toolName, args) -> false)
+                .run("delete the thread group", null, progressLines::add);
+
+        assertTrue(result.isCompleted());
+        assertEquals("Okay, I will not delete it.", result.getFinalText());
+        assertTrue(progressLines.stream().anyMatch(l -> l.contains("declined")));
+    }
+
+    @Test
+    void run_toolCallResult_isFedBackAsAToolMessage() {
+        Deque<ChatCompletion> responses = new ArrayDeque<>();
+        responses.add(toolCompletion("call_1", "get_tree_state", "{}"));
+        responses.add(textCompletion("Here's the tree."));
+        List<ChatCompletionCreateParams> captured = new ArrayList<>();
+        OpenAiChatModel.CompletionService service = params -> {
+            captured.add(params);
+            return responses.removeFirst();
+        };
+
+        AgentLoop.AgentResult result = agent(service, null).run("show me the tree", null);
+
+        assertTrue(result.isCompleted());
+        assertEquals(2, result.getIterations());
+        List<com.openai.models.chat.completions.ChatCompletionMessageParam> second = captured.get(1).messages();
+        assertTrue(second.get(second.size() - 1).isTool());
+    }
+}

--- a/src/test/java/org/qainsights/jmeter/ai/agent/JMeterAgentProviderWiringTest.java
+++ b/src/test/java/org/qainsights/jmeter/ai/agent/JMeterAgentProviderWiringTest.java
@@ -1,0 +1,65 @@
+package org.qainsights.jmeter.ai.agent;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.qainsights.jmeter.ai.service.AiService;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Unit tests for {@link JMeterAgent}'s provider selection and factory validation. */
+class JMeterAgentProviderWiringTest {
+
+    /** A provider with no tool-calling adapter (e.g. Ollama, Gemini, Bedrock). */
+    private static final class UnsupportedService implements AiService {
+        @Override
+        public String generateResponse(List<String> conversation) {
+            return "";
+        }
+
+        @Override
+        public String generateResponse(List<String> conversation, String model) {
+            return "";
+        }
+
+        @Override
+        public String getName() {
+            return "unsupported";
+        }
+    }
+
+    @Test
+    void forService_unsupportedProvider_returnsNullSoTheCallerCanDegrade() {
+        assertNull(JMeterAgent.forService(new UnsupportedService()));
+    }
+
+    @Test
+    void forService_nullService_returnsNull() {
+        assertNull(JMeterAgent.forService(null));
+    }
+
+    @Test
+    void constructor_nullChatModelFactory_isRejected() {
+        assertThrows(IllegalArgumentException.class, () -> new JMeterAgent(null, 5, null));
+    }
+
+    @Test
+    void claudeFactory_buildsAChatModelPerRun() {
+        AgentChatModelFactory factory = JMeterAgent.claudeFactory(params -> {
+            throw new IllegalStateException("not called");
+        }, "claude", 1024);
+
+        assertNotNull(factory.create(java.util.Collections.emptyList(), "system",
+                java.util.Collections.emptyList()));
+    }
+
+    @Test
+    void openAiFactory_buildsAChatModelPerRun() {
+        AgentChatModelFactory factory = JMeterAgent.openAiFactory(params -> {
+            throw new IllegalStateException("not called");
+        }, "gpt-4o", 1024);
+
+        assertNotNull(factory.create(java.util.Collections.emptyList(), "system",
+                java.util.Collections.emptyList()));
+    }
+}

--- a/src/test/java/org/qainsights/jmeter/ai/agent/openai/OpenAiChatModelTest.java
+++ b/src/test/java/org/qainsights/jmeter/ai/agent/openai/OpenAiChatModelTest.java
@@ -1,0 +1,235 @@
+package org.qainsights.jmeter.ai.agent.openai;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.qainsights.jmeter.ai.agent.loop.AssistantTurn;
+import org.qainsights.jmeter.ai.agent.loop.ToolOutcome;
+import org.qainsights.jmeter.ai.agent.tool.ParamType;
+import org.qainsights.jmeter.ai.agent.tool.ToolParameter;
+import org.qainsights.jmeter.ai.agent.tool.ToolSpec;
+
+import com.openai.core.JsonValue;
+import com.openai.models.ReasoningEffort;
+import com.openai.models.chat.completions.ChatCompletion;
+import com.openai.models.chat.completions.ChatCompletionCreateParams;
+import com.openai.models.chat.completions.ChatCompletionMessageParam;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Unit tests for {@link OpenAiChatModel} using a fake {@link OpenAiChatModel.CompletionService}. */
+class OpenAiChatModelTest {
+
+    /** Builds a real ChatCompletion from its JSON shape, bypassing strict builders. */
+    private static ChatCompletion completion(Map<String, Object> message) {
+        Map<String, Object> choice = new LinkedHashMap<>();
+        choice.put("index", 0);
+        choice.put("finish_reason", "stop");
+        choice.put("message", message);
+
+        Map<String, Object> json = new LinkedHashMap<>();
+        json.put("id", "chatcmpl_1");
+        json.put("object", "chat.completion");
+        json.put("created", 0);
+        json.put("model", "gpt-4o");
+        json.put("choices", Collections.singletonList(choice));
+        return JsonValue.from(json).convert(ChatCompletion.class);
+    }
+
+    private static ChatCompletion textCompletion(String text) {
+        Map<String, Object> message = new LinkedHashMap<>();
+        message.put("role", "assistant");
+        message.put("content", text);
+        return completion(message);
+    }
+
+    private static ChatCompletion toolCompletion(String id, String name) {
+        Map<String, Object> function = new LinkedHashMap<>();
+        function.put("name", name);
+        function.put("arguments", "{}");
+        Map<String, Object> call = new LinkedHashMap<>();
+        call.put("id", id);
+        call.put("type", "function");
+        call.put("function", function);
+
+        Map<String, Object> message = new LinkedHashMap<>();
+        message.put("role", "assistant");
+        message.put("content", null);
+        message.put("tool_calls", Collections.singletonList(call));
+        return completion(message);
+    }
+
+    private static ChatCompletion emptyChoicesCompletion() {
+        Map<String, Object> json = new LinkedHashMap<>();
+        json.put("id", "chatcmpl_1");
+        json.put("object", "chat.completion");
+        json.put("created", 0);
+        json.put("model", "gpt-4o");
+        json.put("choices", Collections.emptyList());
+        return JsonValue.from(json).convert(ChatCompletion.class);
+    }
+
+    private static OpenAiChatModel model(OpenAiChatModel.CompletionService service) {
+        return new OpenAiChatModel(service, new OpenAiToolAdapter(),
+                Collections.<ToolSpec>emptyList(), "system", "gpt-4o", 1024);
+    }
+
+    @Test
+    void start_sendsUserMessageAndParsesToolCall() {
+        List<ChatCompletionCreateParams> captured = new ArrayList<>();
+        OpenAiChatModel.CompletionService service = params -> {
+            captured.add(params);
+            return toolCompletion("call_1", "get_tree_state");
+        };
+
+        AssistantTurn turn = model(service).start("inspect the plan");
+
+        assertTrue(turn.hasToolCalls());
+        assertEquals("get_tree_state", turn.getToolCalls().get(0).getName());
+        // system prompt + the user message.
+        assertEquals(2, captured.get(0).messages().size());
+        assertTrue(captured.get(0).messages().get(0).isSystem());
+        assertTrue(captured.get(0).messages().get(1).isUser());
+    }
+
+    @Test
+    void next_appendsToolResultsAndGrowsHistory() {
+        Deque<ChatCompletion> responses = new ArrayDeque<>();
+        responses.add(toolCompletion("call_1", "get_tree_state"));
+        responses.add(textCompletion("All set."));
+        List<ChatCompletionCreateParams> captured = new ArrayList<>();
+        OpenAiChatModel.CompletionService service = params -> {
+            captured.add(params);
+            return responses.removeFirst();
+        };
+
+        OpenAiChatModel chat = model(service);
+        chat.start("inspect");
+        AssistantTurn turn = chat.next(Collections.singletonList(
+                new ToolOutcome("call_1", "get_tree_state", "tree", false)));
+
+        assertFalse(turn.hasToolCalls());
+        assertEquals("All set.", turn.getText());
+        // 2nd call: system + user + assistant(tool_calls) + tool result = 4.
+        assertEquals(4, captured.get(1).messages().size());
+        assertTrue(captured.get(1).messages().get(2).isAssistant());
+        assertTrue(captured.get(1).messages().get(3).isTool());
+    }
+
+    @Test
+    void send_advertisesEveryToolSpec() {
+        List<ChatCompletionCreateParams> captured = new ArrayList<>();
+        OpenAiChatModel.CompletionService service = params -> {
+            captured.add(params);
+            return textCompletion("ok");
+        };
+        List<ToolSpec> specs = Arrays.asList(
+                ToolSpec.builder("get_tree_state").description("Reads the tree").build(),
+                ToolSpec.builder("add_element").description("Adds an element")
+                        .addParameter(ToolParameter.builder("parent_id", ParamType.STRING).required(true).build())
+                        .build());
+
+        new OpenAiChatModel(service, new OpenAiToolAdapter(), specs, "system", "gpt-4o", 1024).start("hi");
+
+        List<com.openai.models.chat.completions.ChatCompletionTool> tools =
+                captured.get(0).tools().orElse(Collections.emptyList());
+        assertEquals(2, tools.size());
+        assertEquals("get_tree_state", tools.get(0).asFunction().function().name());
+        assertEquals("add_element", tools.get(1).asFunction().function().name());
+    }
+
+    @Test
+    void send_setsModelAndMaxCompletionTokensButNotTemperature() {
+        List<ChatCompletionCreateParams> captured = new ArrayList<>();
+        OpenAiChatModel.CompletionService service = params -> {
+            captured.add(params);
+            return textCompletion("ok");
+        };
+
+        model(service).start("hi");
+
+        assertEquals("gpt-4o", captured.get(0).model().asString());
+        assertEquals(1024L, captured.get(0).maxCompletionTokens().orElse(0L));
+        // Reasoning models (o1/o3/o4/gpt-5) reject a custom temperature, so it is never set.
+        assertFalse(captured.get(0).temperature().isPresent());
+        assertFalse(captured.get(0).reasoningEffort().isPresent());
+    }
+
+    @Test
+    void send_gpt5DottedMinorModel_disablesReasoningSoFunctionToolsAreAccepted() {
+        List<ChatCompletionCreateParams> captured = new ArrayList<>();
+        OpenAiChatModel.CompletionService service = params -> {
+            captured.add(params);
+            return textCompletion("ok");
+        };
+
+        new OpenAiChatModel(service, new OpenAiToolAdapter(), Collections.<ToolSpec>emptyList(),
+                "system", "gpt-5.6-terra", 1024).start("hi");
+
+        assertEquals(ReasoningEffort.NONE, captured.get(0).reasoningEffort().orElse(null),
+                "gpt-5.1+ rejects function tools unless reasoning_effort is 'none'");
+    }
+
+    @Test
+    void constructor_withSeedHistory_prependsItToTheFirstRequest() {
+        List<ChatCompletionCreateParams> captured = new ArrayList<>();
+        OpenAiChatModel.CompletionService service = params -> {
+            captured.add(params);
+            return textCompletion("ok");
+        };
+        List<ChatCompletionMessageParam> seed =
+                OpenAiChatModel.toSeedHistory(Arrays.asList("earlier question", "earlier answer"));
+
+        new OpenAiChatModel(service, new OpenAiToolAdapter(), Collections.<ToolSpec>emptyList(),
+                "system", "gpt-4o", 1024, seed).start("follow up");
+
+        // system + seed (2) + the new user message (1) = 4.
+        assertEquals(4, captured.get(0).messages().size());
+        assertTrue(captured.get(0).messages().get(1).isUser());
+        assertTrue(captured.get(0).messages().get(2).isAssistant());
+    }
+
+    @Test
+    void constructor_withoutSeedHistory_sendsOnlyTheNewMessage() {
+        List<ChatCompletionCreateParams> captured = new ArrayList<>();
+        OpenAiChatModel.CompletionService service = params -> {
+            captured.add(params);
+            return textCompletion("ok");
+        };
+
+        model(service).start("hello");
+
+        assertEquals(2, captured.get(0).messages().size());
+    }
+
+    @Test
+    void toSeedHistory_nullTurns_returnsEmptyList() {
+        assertTrue(OpenAiChatModel.toSeedHistory(null).isEmpty());
+    }
+
+    @Test
+    void toSeedHistory_alternatesUserThenAssistant() {
+        List<ChatCompletionMessageParam> seed =
+                OpenAiChatModel.toSeedHistory(Arrays.asList("q1", "a1", "q2", "a2"));
+
+        assertEquals(4, seed.size());
+        assertTrue(seed.get(0).isUser());
+        assertTrue(seed.get(1).isAssistant());
+        assertTrue(seed.get(2).isUser());
+        assertTrue(seed.get(3).isAssistant());
+    }
+
+    @Test
+    void send_noChoices_throwsInsteadOfReturningAnEmptyTurn() {
+        OpenAiChatModel.CompletionService service = params -> emptyChoicesCompletion();
+
+        assertThrows(IllegalStateException.class, () -> model(service).start("hi"));
+    }
+}

--- a/src/test/java/org/qainsights/jmeter/ai/agent/openai/OpenAiReasoningPolicyTest.java
+++ b/src/test/java/org/qainsights/jmeter/ai/agent/openai/OpenAiReasoningPolicyTest.java
@@ -1,0 +1,49 @@
+package org.qainsights.jmeter.ai.agent.openai;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import com.openai.models.ReasoningEffort;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Unit tests for {@link OpenAiReasoningPolicy}. */
+class OpenAiReasoningPolicyTest {
+
+    @Test
+    void gpt5DottedMinorModels_mustDisableReasoningForToolCalling() {
+        assertEquals(Optional.of(ReasoningEffort.NONE), OpenAiReasoningPolicy.forToolCalling("gpt-5.1"));
+        assertEquals(Optional.of(ReasoningEffort.NONE), OpenAiReasoningPolicy.forToolCalling("gpt-5.6-terra"));
+        assertEquals(Optional.of(ReasoningEffort.NONE), OpenAiReasoningPolicy.forToolCalling("gpt-5.6-sol"));
+        assertEquals(Optional.of(ReasoningEffort.NONE), OpenAiReasoningPolicy.forToolCalling("gpt-5.1-codex"));
+    }
+
+    @Test
+    void originalGpt5Line_isLeftAlone() {
+        assertFalse(OpenAiReasoningPolicy.forToolCalling("gpt-5").isPresent());
+        assertFalse(OpenAiReasoningPolicy.forToolCalling("gpt-5-mini").isPresent());
+        assertFalse(OpenAiReasoningPolicy.forToolCalling("gpt-5-nano").isPresent());
+    }
+
+    @Test
+    void nonReasoningAndOSeriesModels_areLeftAlone() {
+        assertFalse(OpenAiReasoningPolicy.forToolCalling("gpt-4o").isPresent());
+        assertFalse(OpenAiReasoningPolicy.forToolCalling("gpt-4.1").isPresent());
+        assertFalse(OpenAiReasoningPolicy.forToolCalling("o1").isPresent());
+        assertFalse(OpenAiReasoningPolicy.forToolCalling("o3-mini").isPresent());
+        assertFalse(OpenAiReasoningPolicy.forToolCalling("o4-mini").isPresent());
+    }
+
+    @Test
+    void modelIdIsMatchedCaseInsensitivelyAndTrimmed() {
+        assertTrue(OpenAiReasoningPolicy.requiresDisabledReasoning("  GPT-5.6-Terra  "));
+    }
+
+    @Test
+    void nullOrEmptyModel_isLeftAlone() {
+        assertFalse(OpenAiReasoningPolicy.requiresDisabledReasoning(null));
+        assertFalse(OpenAiReasoningPolicy.requiresDisabledReasoning(""));
+        assertFalse(OpenAiReasoningPolicy.forToolCalling(null).isPresent());
+    }
+}

--- a/src/test/java/org/qainsights/jmeter/ai/agent/openai/OpenAiToolAdapterTest.java
+++ b/src/test/java/org/qainsights/jmeter/ai/agent/openai/OpenAiToolAdapterTest.java
@@ -1,0 +1,191 @@
+package org.qainsights.jmeter.ai.agent.openai;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.qainsights.jmeter.ai.agent.loop.AssistantTurn;
+import org.qainsights.jmeter.ai.agent.loop.ToolOutcome;
+import org.qainsights.jmeter.ai.agent.tool.ParamType;
+import org.qainsights.jmeter.ai.agent.tool.ToolParameter;
+import org.qainsights.jmeter.ai.agent.tool.ToolSpec;
+
+import com.openai.core.JsonValue;
+import com.openai.models.FunctionDefinition;
+import com.openai.models.chat.completions.ChatCompletionFunctionTool;
+import com.openai.models.chat.completions.ChatCompletionMessage;
+import com.openai.models.chat.completions.ChatCompletionToolMessageParam;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Unit tests for {@link OpenAiToolAdapter}. */
+class OpenAiToolAdapterTest {
+
+    private final OpenAiToolAdapter adapter = new OpenAiToolAdapter();
+
+    /** Builds a real assistant message from its JSON shape, bypassing strict builders. */
+    private static ChatCompletionMessage message(String content, Object... toolCalls) {
+        Map<String, Object> json = new LinkedHashMap<>();
+        json.put("role", "assistant");
+        json.put("content", content);
+        if (toolCalls.length > 0) {
+            json.put("tool_calls", Arrays.asList(toolCalls));
+        }
+        return JsonValue.from(json).convert(ChatCompletionMessage.class);
+    }
+
+    private static Map<String, Object> functionCall(String id, String name, String arguments) {
+        Map<String, Object> function = new LinkedHashMap<>();
+        function.put("name", name);
+        function.put("arguments", arguments);
+        Map<String, Object> call = new LinkedHashMap<>();
+        call.put("id", id);
+        call.put("type", "function");
+        call.put("function", function);
+        return call;
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void toOpenAiTool_mapsNameDescriptionSchemaAndRequired() {
+        ToolSpec spec = ToolSpec.builder("update_element_property")
+                .description("Sets a property")
+                .addParameter(ToolParameter.builder("element_id", ParamType.STRING)
+                        .description("the id").required(true).build())
+                .addParameter(ToolParameter.builder("method", ParamType.STRING)
+                        .enumValues(Arrays.asList("GET", "POST")).build())
+                .build();
+
+        ChatCompletionFunctionTool tool = adapter.toOpenAiTool(spec);
+
+        FunctionDefinition function = tool.function();
+        assertEquals("update_element_property", function.name());
+        assertEquals("Sets a property", function.description().orElse(""));
+
+        Map<String, JsonValue> schema = function.parameters().get()._additionalProperties();
+        assertEquals("object", schema.get("type").convert(String.class));
+        assertEquals(Collections.singletonList("element_id"), schema.get("required").convert(List.class));
+        Map<String, Object> properties = schema.get("properties").convert(Map.class);
+        assertTrue(properties.containsKey("element_id"));
+        assertTrue(properties.containsKey("method"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void toOpenAiTool_stringArrayParam_setsArrayTypeAndStringItems() {
+        ToolSpec spec = ToolSpec.builder("set_property_list")
+                .description("Replaces a list property")
+                .addParameter(ToolParameter.builder("values", ParamType.STRING_ARRAY)
+                        .description("the values").required(true).build())
+                .build();
+
+        Map<String, JsonValue> schema = adapter.toOpenAiTool(spec).function()
+                .parameters().get()._additionalProperties();
+
+        Map<String, Object> properties = schema.get("properties").convert(Map.class);
+        Map<String, Object> values = (Map<String, Object>) properties.get("values");
+        assertEquals("array", values.get("type"));
+        assertEquals(Collections.singletonMap("type", "string"), values.get("items"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void toOpenAiTool_noParameters_stillSendsAnObjectSchema() {
+        Map<String, JsonValue> schema = adapter.toOpenAiTool(ToolSpec.builder("get_tree_state").build())
+                .function().parameters().get()._additionalProperties();
+
+        assertEquals("object", schema.get("type").convert(String.class));
+        assertTrue(schema.get("properties").convert(Map.class).isEmpty());
+        assertTrue(schema.get("required").convert(List.class).isEmpty());
+    }
+
+    @Test
+    void toAssistantTurn_extractsTextAndToolCalls() {
+        ChatCompletionMessage response = message("Adding it now.",
+                functionCall("call_42", "add_element", "{\"parent_id\":\"Test Plan\"}"));
+
+        AssistantTurn turn = adapter.toAssistantTurn(response);
+
+        assertEquals("Adding it now.", turn.getText());
+        assertTrue(turn.hasToolCalls());
+        AssistantTurn.ToolCall call = turn.getToolCalls().get(0);
+        assertEquals("call_42", call.getId());
+        assertEquals("add_element", call.getName());
+        assertEquals("Test Plan", call.getArguments().get("parent_id"));
+    }
+
+    @Test
+    void toAssistantTurn_noContentAndNoToolCalls_yieldsEmptyTurn() {
+        AssistantTurn turn = adapter.toAssistantTurn(message(null));
+
+        assertEquals("", turn.getText());
+        assertFalse(turn.hasToolCalls());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void toAssistantTurn_toolCallWithArrayArgument_arrivesAsListOfStrings() {
+        ChatCompletionMessage response = message(null, functionCall("call_9", "set_property_list",
+                "{\"property\":\"Asserion.test_strings\",\"values\":[\"200\",\"201\"]}"));
+
+        AssistantTurn turn = adapter.toAssistantTurn(response);
+
+        List<Object> values = (List<Object>) turn.getToolCalls().get(0).getArguments().get("values");
+        assertEquals(Arrays.asList("200", "201"), values);
+    }
+
+    @Test
+    void toAssistantTurn_malformedArguments_yieldsEmptyArgumentsInsteadOfThrowing() {
+        ChatCompletionMessage response = message(null,
+                functionCall("call_7", "add_element", "{not json"));
+
+        AssistantTurn turn = adapter.toAssistantTurn(response);
+
+        assertTrue(turn.getToolCalls().get(0).getArguments().isEmpty());
+    }
+
+    @Test
+    void toAssistantTurn_emptyArgumentsString_yieldsEmptyArguments() {
+        ChatCompletionMessage response = message(null,
+                functionCall("call_8", "get_tree_state", ""));
+
+        assertTrue(turn(response).getToolCalls().get(0).getArguments().isEmpty());
+    }
+
+    private AssistantTurn turn(ChatCompletionMessage response) {
+        return adapter.toAssistantTurn(response);
+    }
+
+    @Test
+    void toAssistantTurn_multipleToolCalls_arePreservedInOrder() {
+        ChatCompletionMessage response = message(null,
+                functionCall("call_1", "get_tree_state", "{}"),
+                functionCall("call_2", "get_element_config", "{\"element_id\":\"Test Plan\"}"));
+
+        AssistantTurn turn = adapter.toAssistantTurn(response);
+
+        assertEquals(2, turn.getToolCalls().size());
+        assertEquals("get_tree_state", turn.getToolCalls().get(0).getName());
+        assertEquals("get_element_config", turn.getToolCalls().get(1).getName());
+    }
+
+    @Test
+    void toToolMessage_setsToolCallIdAndContent() {
+        ChatCompletionToolMessageParam param = adapter.toToolMessage(
+                new ToolOutcome("call_7", "add_element", "ERROR [bad] nope", true));
+
+        assertEquals("call_7", param.toolCallId());
+        assertEquals("ERROR [bad] nope", param.content().asText());
+    }
+
+    @Test
+    void toToolMessage_successOutcome_carriesTheRawData() {
+        ChatCompletionToolMessageParam param = adapter.toToolMessage(
+                new ToolOutcome("call_1", "get_tree_state", "Test Plan", false));
+
+        assertEquals("Test Plan", param.content().asText());
+    }
+}

--- a/src/test/java/org/qainsights/jmeter/ai/agent/tool/JsonSchemaMapperTest.java
+++ b/src/test/java/org/qainsights/jmeter/ai/agent/tool/JsonSchemaMapperTest.java
@@ -1,0 +1,91 @@
+package org.qainsights.jmeter.ai.agent.tool;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Unit tests for {@link JsonSchemaMapper}, shared by the Claude and OpenAI tool adapters. */
+class JsonSchemaMapperTest {
+
+    private static ToolSpec spec() {
+        return ToolSpec.builder("update_element_property")
+                .description("Sets a property")
+                .addParameter(ToolParameter.builder("element_id", ParamType.STRING)
+                        .description("the id").required(true).build())
+                .addParameter(ToolParameter.builder("method", ParamType.STRING)
+                        .enumValues(Arrays.asList("GET", "POST")).build())
+                .addParameter(ToolParameter.builder("force", ParamType.BOOLEAN).build())
+                .build();
+    }
+
+    @Test
+    void properties_preservesDeclarationOrder() {
+        List<String> keys = new java.util.ArrayList<>(JsonSchemaMapper.properties(spec()).keySet());
+        assertEquals(Arrays.asList("element_id", "method", "force"), keys);
+    }
+
+    @Test
+    void required_listsOnlyRequiredParameters() {
+        assertEquals(Collections.singletonList("element_id"), JsonSchemaMapper.required(spec()));
+    }
+
+    @Test
+    void propertySchema_includesDescriptionAndEnum() {
+        Map<String, Object> properties = JsonSchemaMapper.properties(spec());
+
+        Map<?, ?> elementId = (Map<?, ?>) properties.get("element_id");
+        assertEquals("string", elementId.get("type"));
+        assertEquals("the id", elementId.get("description"));
+        assertFalse(elementId.containsKey("enum"));
+
+        Map<?, ?> method = (Map<?, ?>) properties.get("method");
+        assertEquals(Arrays.asList("GET", "POST"), method.get("enum"));
+        assertFalse(method.containsKey("description"));
+    }
+
+    @Test
+    void propertySchema_stringArray_hasStringItems() {
+        ToolSpec arraySpec = ToolSpec.builder("set_property_list")
+                .addParameter(ToolParameter.builder("values", ParamType.STRING_ARRAY).required(true).build())
+                .build();
+
+        Map<?, ?> values = (Map<?, ?>) JsonSchemaMapper.properties(arraySpec).get("values");
+
+        assertEquals("array", values.get("type"));
+        assertEquals(Collections.singletonMap("type", "string"), values.get("items"));
+    }
+
+    @Test
+    void propertySchema_objectArray_hasObjectItems() {
+        ToolSpec arraySpec = ToolSpec.builder("set_structured_property_list")
+                .addParameter(ToolParameter.builder("entries", ParamType.OBJECT_ARRAY).required(true).build())
+                .build();
+
+        Map<?, ?> entries = (Map<?, ?>) JsonSchemaMapper.properties(arraySpec).get("entries");
+
+        assertEquals("array", entries.get("type"));
+        assertEquals(Collections.singletonMap("type", "object"), entries.get("items"));
+    }
+
+    @Test
+    void jsonType_mapsEveryParamType() {
+        assertEquals("string", JsonSchemaMapper.jsonType(ParamType.STRING));
+        assertEquals("integer", JsonSchemaMapper.jsonType(ParamType.INTEGER));
+        assertEquals("number", JsonSchemaMapper.jsonType(ParamType.NUMBER));
+        assertEquals("boolean", JsonSchemaMapper.jsonType(ParamType.BOOLEAN));
+        assertEquals("object", JsonSchemaMapper.jsonType(ParamType.OBJECT));
+        assertEquals("array", JsonSchemaMapper.jsonType(ParamType.STRING_ARRAY));
+        assertEquals("array", JsonSchemaMapper.jsonType(ParamType.OBJECT_ARRAY));
+    }
+
+    @Test
+    void properties_specWithNoParameters_isEmpty() {
+        assertTrue(JsonSchemaMapper.properties(ToolSpec.builder("get_tree_state").build()).isEmpty());
+        assertTrue(JsonSchemaMapper.required(ToolSpec.builder("get_tree_state").build()).isEmpty());
+    }
+}

--- a/src/test/java/org/qainsights/jmeter/ai/gui/CommandDispatcherIsAgentCapableModelTest.java
+++ b/src/test/java/org/qainsights/jmeter/ai/gui/CommandDispatcherIsAgentCapableModelTest.java
@@ -1,0 +1,73 @@
+package org.qainsights.jmeter.ai.gui;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link CommandDispatcher#isAgentCapableModel(String)}.
+ * Agent mode supports the two providers with tool-calling adapters - Anthropic
+ * Claude (non-prefixed ids) and OpenAI ({@code openai:} prefix); everything else
+ * falls back to the plain chat path.
+ */
+class CommandDispatcherIsAgentCapableModelTest {
+
+    @Test
+    void testNullModel_returnsTrue() {
+        assertTrue(CommandDispatcher.isAgentCapableModel(null),
+                "Null model defaults to Claude, which is agent-capable");
+    }
+
+    @Test
+    void testEmptyModel_returnsTrue() {
+        assertTrue(CommandDispatcher.isAgentCapableModel(""),
+                "Empty model defaults to Claude, which is agent-capable");
+    }
+
+    @Test
+    void testAnthropicModel_returnsTrue() {
+        assertTrue(CommandDispatcher.isAgentCapableModel("claude-sonnet-4-20250514"));
+    }
+
+    @Test
+    void testOpenAiModel_returnsTrue() {
+        assertTrue(CommandDispatcher.isAgentCapableModel("openai:gpt-4o"),
+                "OpenAI now has a tool-calling adapter");
+    }
+
+    @Test
+    void testOpenAiReasoningModel_returnsTrue() {
+        assertTrue(CommandDispatcher.isAgentCapableModel("openai:o3-mini"));
+    }
+
+    @Test
+    void testOllamaModel_returnsFalse() {
+        assertFalse(CommandDispatcher.isAgentCapableModel("ollama:llama3.1"));
+    }
+
+    @Test
+    void testDeepseekModel_returnsFalse() {
+        assertFalse(CommandDispatcher.isAgentCapableModel("deepseek:deepseek-chat"));
+    }
+
+    @Test
+    void testGoogleModel_returnsFalse() {
+        assertFalse(CommandDispatcher.isAgentCapableModel("google:gemini-1.5"));
+    }
+
+    @Test
+    void testGrokModel_returnsFalse() {
+        assertFalse(CommandDispatcher.isAgentCapableModel("grok:grok-2"));
+    }
+
+    @Test
+    void testMetaModel_returnsFalse() {
+        assertFalse(CommandDispatcher.isAgentCapableModel("meta:muse-spark-1.1"));
+    }
+
+    @Test
+    void testBedrockModel_returnsFalse() {
+        assertFalse(CommandDispatcher.isAgentCapableModel("bedrock:anthropic.claude-3-5-sonnet-20241022-v2:0"),
+                "Bedrock has no tool-calling adapter yet");
+    }
+}


### PR DESCRIPTION
- Add OpenAiToolAdapter and OpenAiChatModel for openai-java 4.x integration
- Add OpenAiReasoningPolicy: send reasoning_effort=none for gpt-5.1+ models (fixes 400 Function tools with reasoning_effort for gpt-5.6-terra/sol)
- Generalize JMeterAgent via AgentChatModelFactory and forService/forOpenAi
- Extract shared JsonSchemaMapper and ConversationSeed for provider-neutral tool schemas and conversation history seeding
- Refactor ClaudeToolAdapter and ClaudeChatModel onto shared seams
- Update CommandDispatcher to treat OpenAI models as agent-capable
- Add comprehensive unit + integration tests (975 passing)
- Update README, sample properties, and agent-roadmap
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/qainsights/jmeter-ai/pull/75" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenAI tool-calling to Agent Mode with the same tools and prompts as Claude. Also fixes gpt‑5.x reasoning/tool-call errors and introduces a provider‑neutral factory for future providers.

- **New Features**
  - Added `OpenAiToolAdapter` and `OpenAiChatModel` using `openai-java` 4.x; supports the full agent toolset.
  - Introduced `AgentChatModelFactory` with `forService`/`forOpenAi`; `CommandDispatcher` now treats OpenAI models as agent-capable.
  - Shared `JsonSchemaMapper` and `ConversationSeed` for consistent tool schemas and conversation seeding; updated README and sample properties.

- **Bug Fixes**
  - Implemented `OpenAiReasoningPolicy` to send `reasoning_effort=none` for `gpt-5.1+` on `/v1/chat/completions`, preventing 400 errors when using function tools.

<sup>Written for commit f78f33e9e95b6ce7d98243007afadd1ec625a7c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/QAInsights/jmeter-ai/pull/75?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent Mode now supports both Claude and OpenAI models.
  * OpenAI models can use tools, conversation history, and safety confirmations.
  * Added compatibility guidance for selecting supported models, including GPT-5 reasoning models.

* **Documentation**
  * Updated Agent Mode setup, compatibility notes, examples, and sample configuration to reflect Claude and OpenAI support.

* **Bug Fixes**
  * Improved handling of conversation history and tool-call responses across supported providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->